### PR TITLE
Add a User-Agent header to work around Cloudflare bot protection on WOF data API

### DIFF
--- a/editor/place/views.py
+++ b/editor/place/views.py
@@ -258,7 +258,10 @@ def find_wof_doc(wof_id):
     # Only request the first 10K of the doc to avoid the geometry if it's really big
     resp = requests.get(
         "https://data.whosonfirst.org/" + wof_doc_url_suffix,
-        headers={"Range": "0-10000"},
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+            "Range": "0-10000",
+        },
     )
 
     resp.raise_for_status()


### PR DESCRIPTION
Fixes #60

When trying to find the Github repo for a particular WOF ID, we would ask the data.whosonfirst.org API, which gives us the repo name so we can continue the editing path. This is fronted by Cloudflare's bot protection system and would 403 when we used the default requests library HTTP User-Agent header, so I am setting a Chrome-like User-Agent instead.

This will likely break at some point in the future when the user agent gets too old and Cloudflare catches on.