### PR TITLE
Fix the new concordance form

### DIFF
--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -194,7 +194,7 @@ $(document).ready(function() {
     });
 
     $("#add-concordance").on("click", function(e) {
-        var newRow = $("#new-concordance-row-template").clone();
+        var newRow = $("#new-concordance-row").clone();
         newRow.insertAfter($(".concordance-row").last());
         newRow.addClass("concordance-row");
         newRow.removeAttr("id");
@@ -429,13 +429,13 @@ $(document).ready(function() {
             </div>
         </div>
         {%- endfor %}
-        <div id="new-concordance-row-template" class="form-group" style="display: none;">
+        <div id="new-concordance-row" class="form-group concordance-row">
             <div class="row">
                 <div class="col-sm-4">
-                    <input type="text" class="form-control" name="new-wof:concordances-name" />
+                    <input type="text" class="form-control" name="new-wof:concordances-name" placeholder="wd:id" />
                 </div>
                 <div class="col-sm-8">
-                    <input type="text" class="form-control" name="new-wof:concordances-value" />
+                    <input type="text" class="form-control" name="new-wof:concordances-value" placeholder="Q1234" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #73 

The button to add a new concordance was looking for other concordance form elements after which to add the new row. When there was no concordance, it didn't have anything to append to.

I fixed it by starting the page with a blank so that there's always at least one row in there to append to.