### PR TITLE
[WIP] add geometries HTML section, add Leaflet draw controls

### DIFF
--- a/editor/place/views.py
+++ b/editor/place/views.py
@@ -433,6 +433,10 @@ def edit_place():
                         except ValueError:
                             raise ValidationException("Concordance %s must be an integer" % new_key)
                     wof_doc['properties']['wof:concordances'][new_key] = new_value
+
+            # Update geometries
+            if request.form.get('lbl:bbox'):
+                wof_doc['properties']['lbl:bbox'] = request.form['lbl:bbox']
         except ValidationException as e:
             flash("Problem validating changes: %s" % e)
             return redirect(request.url)

--- a/editor/place/views.py
+++ b/editor/place/views.py
@@ -437,6 +437,15 @@ def edit_place():
             # Update geometries
             if request.form.get('lbl:bbox'):
                 wof_doc['properties']['lbl:bbox'] = request.form['lbl:bbox']
+            if request.form.get('lbl:centroid'):
+                lng, lat = request.form.get('lbl:centroid').split(',')
+                wof_doc['properties']['lbl:longitude'] = float(lng)
+                wof_doc['properties']['lbl:latitude'] = float(lat)
+            if request.form.get('reversegeo:centroid'):
+                lng, lat = request.form.get('reversegeo:centroid').split(',')
+                wof_doc['properties']['reversegeo:longitude'] = float(lng)
+                wof_doc['properties']['reversegeo:latitude'] = float(lat)
+
         except ValidationException as e:
             flash("Problem validating changes: %s" % e)
             return redirect(request.url)

--- a/editor/place/views.py
+++ b/editor/place/views.py
@@ -339,23 +339,23 @@ def edit_place():
     localized_names = parse_prefix_map(wof_doc['properties'], 'name:')
     localized_labels = parse_prefix_map(wof_doc['properties'], 'label:')
 
-    localized_names_tagify_whitelist = []
+    localized_names_tagify_allowlist = []
     for lang in localized_names.keys():
         lang_expanded = lang_expansion.get(lang)
         search_by = [lang, lang_expanded] if lang_expanded else [lang]
 
-        localized_names_tagify_whitelist.append({
+        localized_names_tagify_allowlist.append({
             "lang": lang,
             "value": "%s (%s)" % (lang_expanded, lang) if lang_expanded else lang,
             "searchBy": search_by,
         })
 
-    localized_labels_tagify_whitelist = []
+    localized_labels_tagify_allowlist = []
     for lang in localized_labels.keys():
         lang_expanded = lang_expansion.get(lang)
         search_by = [lang, lang_expanded] if lang_expanded else [lang]
 
-        localized_labels_tagify_whitelist.append({
+        localized_labels_tagify_allowlist.append({
             "lang": lang,
             "value": "%s (%s)" % (lang_expanded, lang) if lang_expanded else lang,
             "searchBy": search_by,
@@ -725,8 +725,8 @@ def edit_place():
         lang_expansion=lang_expansion,
         name_specs=name_specs,
         localized_names=localized_names,
-        localized_names_tagify_whitelist=localized_names_tagify_whitelist,
+        localized_names_tagify_allowlist=localized_names_tagify_allowlist,
         label_specs=label_specs,
         localized_labels=localized_labels,
-        localized_labels_tagify_whitelist=localized_labels_tagify_whitelist,
+        localized_labels_tagify_allowlist=localized_labels_tagify_allowlist,
     )

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -5,6 +5,7 @@
 {%- block styles %}
 {{ super() }}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" />
 <link rel="stylesheet" href="https://unpkg.com/@yaireo/tagify@2.31.6/dist/tagify.css" integrity="sha384-VgQsYt/GtydzxrFEKS4D9VXB6lLQ4cXbFwdorV5HIkxXY8N9e1gJCl36seX6wYYP" crossorigin=""/>
 <style type="text/css">
     #map {
@@ -19,6 +20,7 @@
 {{ super() }}
 <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js" integrity="sha384-sKs8ZrrxyJoElcPVznZwGpUTTXvkMYfHYxdIFzO8Hd0TA6emONMj8BwnsFf+6cZ/" crossorigin=""></script>
+<script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>
 <script src="https://unpkg.com/@yaireo/tagify@2.31.6/dist/jQuery.tagify.min.js" integrity="sha384-oJRpUI+TNL56khhVpM5tcGH6Al77rv1qUUKXqmG0cMe5KtcNzLYfxgdcwunFouVe" crossorigin=""></script>
 <script type="text/javascript">
 $(document).ready(function() {
@@ -60,6 +62,14 @@ $(document).ready(function() {
         maxZoom: 19
     }).addTo(map);
 
+	var drawnItems = new L.FeatureGroup();
+	map.addLayer(drawnItems);
+
+	map.on('draw:created', function (e) {
+	  var layer = e.layer;
+	  drawnItems.addLayer(layer);
+	});
+
     var geomColors = {
         default: '#1f78b4',
         geomCentroid: '#a6cee3',
@@ -67,6 +77,11 @@ $(document).ready(function() {
         labelBbox: '#fb9a99',
         revgeoPoint: '#b2df8a',
     }
+    
+    // drawControl options are data dependent
+    enable_circlemarker = true;
+    enable_polygons = true;
+    enable_rectangle = true;
 
     var featureLayer = L.geoJSON(null, {
         pointToLayer: function(pt, latlng) {
@@ -75,13 +90,23 @@ $(document).ready(function() {
         style: function(f) {
             return {color: geomColors.default};
         },
-    }).addTo(map);
+    }).addTo(drawnItems);
     featureLayer.addData({{ {"type":"Feature","geometry":wof_doc.geometry}|tojson }});
     map.fitBounds(featureLayer.getBounds());
 
+	// Only enable polygon drawing if the default geom is a point not a polygon
+    {% if wof_doc.geometry['type'] != 'Point' -%}
+    enable_polygons = false;
+    {%- endif %}
+
+    {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
+    var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
+    var geomCentroidLayer = L.circleMarker(geomCentroid, {color: geomColors.geomCentroid, radius: 5, title: 'math centroid point'}).addTo(drawnItems);
+    {%- endif %}
+
     {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
     var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
-    var labelPointLayer = L.circleMarker(labelPoint, {color: geomColors.labelPoint}).addTo(map);
+    var labelPointLayer = L.circleMarker(labelPoint, {color: geomColors.labelPoint, title: 'label point'}).addTo(drawnItems);
     {%- endif %}
 
     {%- if wof_doc.properties['lbl:bbox'] is defined %}
@@ -90,18 +115,45 @@ $(document).ready(function() {
         L.latLng({{ bboxParts[1] }}, {{ bboxParts[0] }}),
         L.latLng({{ bboxParts[3] }}, {{ bboxParts[2] }}),
     );
-    var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox}).addTo(map);
+    var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox, title: 'label bounding box'}).addTo(drawnItems);
+	// Disable drawing rectangles if the label bounding box already exists
+    enable_rectangle = false;
     {%- endif %}
 
     {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
     var reverseGeo = L.latLng({{ wof_doc.properties['reversegeo:latitude']|float|tojson }}, {{ wof_doc.properties['reversegeo:longitude']|float|tojson }});
-    var reverseGeoLayer = L.circleMarker(reverseGeo, {color: geomColors.revgeoPoint}).addTo(map);
+    var reverseGeoLayer = L.circleMarker(reverseGeo, {color: geomColors.revgeoPoint, title: 'reverse geocoding point'}).addTo(drawnItems);
     {%- endif %}
 
-    {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
-    var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
-    var geomCentroidLayer = L.circleMarker(geomCentroid, {color: geomColors.geomCentroid, radius: 5}).addTo(map);
-    {%- endif %}
+	// Only enable circlemarker if no label centroid and no revgeo centroid
+    if( labelPoint && reverseGeo ) { enable_circlemarker = false; }
+
+	var drawControl = new L.Control.Draw({
+	  position: 'topright',
+	  draw: {
+		polyline: false,    // Remove line drawing option
+		circle: false,
+		marker: false,
+		circlemarker: enable_circlemarker,
+		polygon: enable_polygons,
+		rectangle: enable_rectangle
+	  },
+	  edit: {
+		featureGroup: drawnItems
+	  }
+	});
+	map.addControl(drawControl);
+
+
+	window.onload = onPageLoad();
+	
+	function onPageLoad() {
+	  if(featureLayer) { document.getElementById("geom_default").checked = true; }
+	  if(geomCentroidLayer) { document.getElementById("geom_math_centroid").checked = true; }
+	  if(labelPointLayer) { document.getElementById("geom_label_centroid").checked = true; }
+	  if(labelBboxLayer) { document.getElementById("geom_label_bounding_box").checked = true; }
+	  if(reverseGeoLayer) { document.getElementById("geom_revgeo_centroid").checked = true; }
+	}
 
     $("input.wof-input").on("change", function() {
         checkValid($(this));
@@ -212,6 +264,34 @@ $(document).ready(function() {
 </div>
 
 <form class="needs-validation" novalidate action="{{ url_for('place.edit_place', url=wof_url) }}" method="POST">
+    <h4>Geometries</h4>
+    <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
+    <div class="form-group">
+        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. Alternate geometries are allowed.</small>
+        {%- if geomCentroidLayer %}
+        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom">
+        {%- else %}
+        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" checked=True>
+        {%- endif %}
+        <label for="geom_default">Default geom</label>&nbsp;<small>(<code>geometry</code>)</small>
+        
+        <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
+        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid">
+        <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom.longitude</code>, <code>geom.latitude</code>)</small>
+
+        <small id="wof-name-help" class="form-text text-muted">The coordinate that specifies a label's east-west position (longitude) and north–south position (latitude). Human-generated or derived from mapshaper.</small>
+        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid">
+        <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl.longitude</code>, <code>lbl.latitude</code>)</small>
+
+        <small id="wof-name-help" class="form-text text-muted">The bounding box area used purely for map labelling and search purposes, and is usually smaller than the geom:bbox. Human-generated (not derived from Mapshaper).</small>
+        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box">
+        <label for="geom_label_bounding_box">Label bounding box</label>&nbsp;<small>(<code>lbl.bbox</code>)</small>
+
+        <small id="wof-name-help" class="form-text text-muted">Typically derived from mapshaper, represents the centroid to use when reverse geocoding a record to establish the parent hierarchy.</small>
+        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid">
+        <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo.longitude</code>, <code>reversegeo.latitude</code>)</small>
+    </div>
+    <h4>Common properties</h4>
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
     <div class="form-group">
         <label for="wof-name">Name</label>&nbsp;<small>(<code>wof:name</code>)</small>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
 <link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" integrity="sha384-NZLkVuBRMEeB4VeZz27WwTRvlhec30biQ8Xx7zG7JJnkvEKRg5qi6BNbEXo9ydwv"" crossorigin=""/>
 <link rel="stylesheet" href="https://unpkg.com/@yaireo/tagify@2.31.6/dist/tagify.css" integrity="sha384-VgQsYt/GtydzxrFEKS4D9VXB6lLQ4cXbFwdorV5HIkxXY8N9e1gJCl36seX6wYYP" crossorigin=""/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@v0.79.0/dist/L.Control.Locate.min.css" integrity="sha384-s1weW3rLvQEcQo1OenCYWESkNoaaT6C995dZ4jgUAt+qkjhTNQoN8mhu6ZwQzWNS" crossorigin=""/>
 <style type="text/css">
     #map {
         width: 100%;
@@ -22,6 +23,7 @@
 <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js" integrity="sha384-sKs8ZrrxyJoElcPVznZwGpUTTXvkMYfHYxdIFzO8Hd0TA6emONMj8BwnsFf+6cZ/" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js" integrity="sha384-JP5UPxIO2Tm2o79Fb0tGYMa44jkWar53aBoCbd8ah0+LcCDoohTIYr+zIXyfGIJN" crossorigin=""></script>
 <script src="https://unpkg.com/@yaireo/tagify@2.31.6/dist/jQuery.tagify.min.js" integrity="sha384-oJRpUI+TNL56khhVpM5tcGH6Al77rv1qUUKXqmG0cMe5KtcNzLYfxgdcwunFouVe" crossorigin=""></script>
+<script src="https://unpkg.com/leaflet.locatecontrol@v0.79.0/dist/L.Control.Locate.min.js"  integrity="sha384-XF7O0sxpctKl96bCyBgbgdQbnHDg/ek0LdbWrVUmx/LPh4EDtdIsGculgF93z6wW" crossorigin=""></script>
 <script type="text/javascript">
 $(document).ready(function() {
     function checkValid(field) {
@@ -61,6 +63,8 @@ $(document).ready(function() {
         minZoom: 0,
         maxZoom: 19
     }).addTo(map);
+
+    L.control.locate().addTo(map);
 
     var drawnItems = new L.FeatureGroup().addTo(map);
 

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -20,7 +20,7 @@
 {{ super() }}
 <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js" integrity="sha384-sKs8ZrrxyJoElcPVznZwGpUTTXvkMYfHYxdIFzO8Hd0TA6emONMj8BwnsFf+6cZ/" crossorigin=""></script>
-<script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js" integrity="ha384-JP5UPxIO2Tm2o79Fb0tGYMa44jkWar53aBoCbd8ah0+LcCDoohTIYr+zIXyfGIJN" crossorigin=""></script>
+<script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js" integrity="sha384-JP5UPxIO2Tm2o79Fb0tGYMa44jkWar53aBoCbd8ah0+LcCDoohTIYr+zIXyfGIJN" crossorigin=""></script>
 <script src="https://unpkg.com/@yaireo/tagify@2.31.6/dist/jQuery.tagify.min.js" integrity="sha384-oJRpUI+TNL56khhVpM5tcGH6Al77rv1qUUKXqmG0cMe5KtcNzLYfxgdcwunFouVe" crossorigin=""></script>
 <script type="text/javascript">
 $(document).ready(function() {
@@ -62,13 +62,7 @@ $(document).ready(function() {
         maxZoom: 19
     }).addTo(map);
 
-    var drawnItems = new L.FeatureGroup();
-    map.addLayer(drawnItems);
-
-    map.on('draw:created', function (e) {
-      var layer = e.layer;
-      drawnItems.addLayer(layer);
-    });
+    var drawnItems = new L.FeatureGroup().addTo(map);
 
     var geomColors = {
         default: '#1f78b4',
@@ -79,62 +73,146 @@ $(document).ready(function() {
     }
     
     // drawControl options are data dependent
-    enable_circlemarker = true;
-    enable_polygons = true;
-    enable_rectangle = true;
+    var count_circlemarker = 0;
+    var count_polygon = 0;
+    var count_rectangle = 0;
+    var enable_circlemarker = true;
+    var enable_polygon = true;
+    var enable_rectangle = true;
+    var has_default_geom_polygon = false;
+    var has_default_geom_point = false;
+    var has_math_centroid = false;
+    var has_label_centroid = false;
+    var has_label_bbox = false;
+    var has_revGeo_centroid = false;
+    var popup_text_default_geom_polygon = "default geometry (polygon)";
+    var popup_text_default_geom_point = "default geometry (point)";
+    var popup_text_math_centroid = "math centroid point";
+    var popup_text_label_centroid = "label point";
+    var popup_text_label_bbox = "label bounding box";
+    var popup_text_revGeo_centroid = "reverse geocoding point";
+    // TODO: Leaflet requires the layer overlays to be added in incrementing z-order
+    //       If you want to reorder, you have to remove all and then add back (omg)
+    //       The ideal z-ordering is below (not implemented)
+    var options_default_geom_polygon = {color: geomColors.default};                           // zIndex: 100
+    var options_default_geom_point = {color: geomColors.default};                             // zIndex: 203
+    var options_math_centroid = {color: geomColors.geomCentroid, radius: 5, draggable: true}; // zIndex: 200
+    var options_label_centroid = {color: geomColors.labelPoint, draggable: true};             // zIndex: 202
+    var options_label_bbox = {color: geomColors.labelBbox, draggable: true};                  // zIndex: 101
+    var options_revGeo_centroid = {color: geomColors.revgeoPoint, draggable: true};           // zIndex: 201
+    var z_offset_default_geom_polygon = 0;
+    var z_offset_default_geom_point = 3;
+    var z_offset_math_centroid = 0;
+    var z_offset_label_centroid = 2;
+    var z_offset_label_bbox = 1;
+    var z_offset_revGeo_centroid = 1;
 
-    var featureLayer = L.geoJSON(null, {
-        pointToLayer: function(pt, latlng) {
-            return L.circleMarker(latlng, {color: geomColors.default});
-        },
-        style: function(f) {
-            return {color: geomColors.default};
-        },
-    }).addTo(drawnItems);
-    featureLayer.addData({{ {"type":"Feature","geometry":wof_doc.geometry}|tojson }});
-    map.fitBounds(featureLayer.getBounds());
-    featureLayer.bindPopup("default geometry");
+    function drawGeoms() {
+      count_circlemarker = 0;
+      count_polygon = 0;
+      count_rectangle = 0;
+      has_default_geom_polygon = false;
+      has_default_geom_point = false;
+      has_math_centroid = false;
+      has_label_centroid = false;
+      has_label_bbox = false;
+      has_revGeo_centroid = false;
 
-    // Only enable polygon drawing if the default geom is a point not a polygon
-    {% if wof_doc.geometry['type'] != 'Point' -%}
-    enable_polygons = false;
-    {%- endif %}
+      var featureLayer = L.geoJSON(null, {
+          pointToLayer: function(pt, latlng) {
+              has_default_geom_polygon = false;
+              has_default_geom_point = true;
+              return L.circleMarker(latlng, options_default_geom_point);
+          },
+          style: function(f) {
+              return options_default_geom_polygon;
+          },
+      }).addTo(drawnItems);
+      featureLayer.addData({{ {"type":"Feature","geometry":wof_doc.geometry}|tojson }});
+      featureLayer.bindPopup(popup_text_default_geom_point);
+      map.fitBounds(featureLayer.getBounds());
+    
+      // Only enable polygon drawing if the default geom is a point not a polygon
+      {% if wof_doc.geometry['type'] != 'Point' -%}
+      featureLayer.bindPopup(popup_text_default_geom_polygon);
+      count_polygon++;
+      enable_polygon = false;
+      has_default_geom_polygon = true;
+      has_default_geom_point = false;
+      {%- endif %}
 
-    {%- if wof_doc.properties['lbl:bbox'] is defined %}
-    {%- set bboxParts = wof_doc.properties['lbl:bbox'].split(",")|list -%}
-    var labelBbox = L.latLngBounds(
-        L.latLng({{ bboxParts[1] }}, {{ bboxParts[0] }}),
-        L.latLng({{ bboxParts[3] }}, {{ bboxParts[2] }}),
-    );
-    var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox, title: 'label bounding box'}).addTo(drawnItems);
-    map.fitBounds(featureLayer.getBounds().extend(labelBboxLayer.getBounds()));
-    // Point default geoms sometimes have a label bounding box that is larger, zoom out to it
-    labelBboxLayer.bindPopup("label bounding box");
-    // Disable drawing rectangles if the label bounding box already exists
-    enable_rectangle = false;
-    {%- endif %}
+      {%- if wof_doc.properties['lbl:bbox'] is defined %}
+      {%- set bboxParts = wof_doc.properties['lbl:bbox'].split(",")|list -%}
+      var labelBbox = L.latLngBounds(
+          L.latLng({{ bboxParts[1] }}, {{ bboxParts[0] }}),
+          L.latLng({{ bboxParts[3] }}, {{ bboxParts[2] }}),
+      );
+      var labelBboxLayer = L.rectangle(labelBbox, options_label_bbox ).addTo(drawnItems);
+      map.fitBounds(featureLayer.getBounds().extend(labelBboxLayer.getBounds()));
+      // Point default geoms sometimes have a label bounding box that is larger, zoom out to it
+      labelBboxLayer.bindPopup(popup_text_label_bbox);
+      // Disable drawing rectangles if the label bounding box already exists
+      enable_rectangle = false;
+      count_rectangle++;
+      has_label_bbox = true;
+      {%- endif %}
 
-    {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
-    var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
-    var geomCentroidLayer = L.circleMarker(geomCentroid, {color: geomColors.geomCentroid, radius: 5, title: 'math centroid point'}).addTo(drawnItems);
-    geomCentroidLayer.bindPopup("math centroid point");
-    {%- endif %}
+      {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
+      var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
+      var geomCentroidLayer = L.circleMarker(geomCentroid, options_math_centroid).addTo(drawnItems);
+      geomCentroidLayer.bindPopup(popup_text_math_centroid);
+      // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
+      drawnItems.addLayer(geomCentroidLayer);
+      has_math_centroid = true;
+      {%- endif %}
 
-    {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
-    var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
-    var labelPointLayer = L.circleMarker(labelPoint, {color: geomColors.labelPoint, title: 'label point'}).addTo(drawnItems);
-    labelPointLayer.bindPopup("label point");
-    {%- endif %}
+      {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
+      var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
+      var labelPointLayer = L.circleMarker(labelPoint, options_label_centroid).addTo(drawnItems);
+      labelPointLayer.bindPopup(popup_text_label_centroid);
+      // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
+      drawnItems.addLayer(labelPointLayer);
+      count_circlemarker++;
+      has_label_centroid = true;
+      {%- endif %}
 
-    {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
-    var reverseGeo = L.latLng({{ wof_doc.properties['reversegeo:latitude']|float|tojson }}, {{ wof_doc.properties['reversegeo:longitude']|float|tojson }});
-    var reverseGeoLayer = L.circleMarker(reverseGeo, {color: geomColors.revgeoPoint, title: 'reverse geocoding point'}).addTo(drawnItems);
-    reverseGeoLayer.bindPopup("reverse geocoding point");
-    {%- endif %}
+      {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
+      var reverseGeo = L.latLng({{ wof_doc.properties['reversegeo:latitude']|float|tojson }}, {{ wof_doc.properties['reversegeo:longitude']|float|tojson }});
+      var reverseGeoLayer = L.circleMarker(reverseGeo, options_revGeo_centroid).addTo(drawnItems);
+      reverseGeoLayer.bindPopup(popup_text_revGeo_centroid);
+      // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
+      drawnItems.addLayer(reverseGeoLayer);
+      count_circlemarker++;
+      has_revGeo_centroid = true;
+      {%- endif %}
 
-    {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
-    enable_circlemarker = false;
-    {%- endif %}
+      {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
+      enable_circlemarker = false;
+      {%- endif %}
+    }
+    
+    drawGeoms();
+    
+    // Define a custom Leaflet control for the reset button
+    var ResetButton = L.Control.extend({
+      onAdd: function(map) {
+        var button = L.DomUtil.create('button', 'leaflet-control-reset');
+        button.innerHTML = 'Reset geometries';
+        button.title = 'Reset geometries';
+
+        L.DomEvent.on(button, 'click', function() {
+          drawnItems.clearLayers();
+          // Add your logic to restore earlier state if necessary
+          drawGeoms();
+          updateDrawOptions();
+        });
+
+        return button;
+      }
+    });
+
+    // Create an instance of the custom control and add it to the map
+    new ResetButton({ position: 'topright' }).addTo(map);
 
     var drawControl = new L.Control.Draw({
       position: 'topright',
@@ -143,7 +221,7 @@ $(document).ready(function() {
         circle: false,
         marker: false,
         circlemarker: enable_circlemarker,
-        polygon: enable_polygons,
+        polygon: enable_polygon,
         rectangle: enable_rectangle
       },
       edit: {
@@ -151,10 +229,156 @@ $(document).ready(function() {
       }
     });
     map.addControl(drawControl);
+    
+    function updateDrawOptions() {
+      if( count_circlemarker >= 2 ) {
+        drawControl.setDrawingOptions({ circlemarker: false });
+      } else {
+        drawControl.setDrawingOptions({ circlemarker: true });
+      }
+      if( count_polygon >= 1 ) {
+        drawControl.setDrawingOptions({ polygon: false });
+      } else {
+        drawControl.setDrawingOptions({ polygon: true });
+      }
+      if( count_rectangle >= 1 ) {
+        drawControl.setDrawingOptions({ rectangle: false });
+      } else {
+        drawControl.setDrawingOptions({ rectangle: true });
+      }
+      // to work around bug in the Leaflet Draw plugin, remove it and add it back for new options to take effect
+      map.removeControl(drawControl);
+      map.addControl(drawControl);
+    }
 
+    map.on('draw:created', function (e) {
+      var layer = e.layer;
+      
+      if (layer instanceof L.CircleMarker) {
+        if (count_circlemarker>=2) {
+          map.removeLayer(layer);
+          return;
+        }
+        circleMarkerAdded = true;
+        drawControl.setDrawingOptions({ marker: false }); // Disable marker drawing option
+        
+        count_circlemarker++;
+        updateDrawOptions();
 
+        var labelPrompt = document.createElement('div');
+        labelPrompt.innerHTML = `
+          <p><b>Select the label type:</b></p>
+        `;
+        if( !has_label_centroid ) {
+          // (nvkelso 20240329: whitespace in value + popup_text var is meaningful)
+          labelPrompt.innerHTML += `
+            <input type="radio" id="label" name="labelType" value="` + popup_text_label_centroid + `">
+            <label for="label">Label Centroid</label><br>
+          `;
+        }
+        if( !has_revGeo_centroid ) {
+          labelPrompt.innerHTML += `
+            <input type="radio" id="reverse" name="labelType" value="` + popup_text_revGeo_centroid + `">
+            <label for="reverse">Reverse Geocoding Centroid</label><br>
+          `;
+        }
+        labelPrompt.innerHTML += `
+        <button id="submitLabelType">Submit</button>
+        `;
+
+        L.DomEvent.disableClickPropagation(labelPrompt);
+
+        L.DomEvent.on(labelPrompt, 'click', function (e) {
+          if (e.target.id === 'submitLabelType') {
+            var selectedRadio = labelPrompt.querySelector('input[name="labelType"]:checked');
+            if (selectedRadio) {
+              labelType = selectedRadio.value;
+              
+              switch( labelType ) {
+                case popup_text_label_centroid: 
+                  has_label_centroid = true;
+                  layer.setStyle( options_label_centroid );
+                  // TODO: Add setting of WOF geometry
+                  break;
+                case popup_text_revGeo_centroid: 
+                  has_revGeo_centroid = true;
+                  layer.setStyle(options_revGeo_centroid);
+                  // TODO: Add setting of WOF geometry
+                  break;
+                default:
+                  //console.log( labelType );
+                  break;
+              }
+              
+              layer.options.title = labelType;
+              layer.bindPopup(labelType);
+
+              // TODO: Should block adding new circlemarkers until the dialog is submitted
+              // TODO: Something here blocks editing of the added layer?
+              drawnItems.addLayer(layer);
+              map.removeControl(labelPrompt);
+            } else {
+              alert('Please select a label type.');
+            }
+          }
+        });
+
+        labelPrompt.style.position = 'absolute'; // Set position to absolute
+        labelPrompt.style.top = '10px'; // Adjust top position
+        labelPrompt.style.left = '10px'; // Adjust left position
+        labelPrompt.style.zIndex = 1000; // Set higher z-index
+        labelPrompt.style.backgroundColor = 'white'; // Set background color
+        labelPrompt.style.border = '2px solid black'; // Set border
+        labelPrompt.style.padding = '10px'; // Add padding
+      
+        map.getContainer().appendChild(labelPrompt);
+      } else if (layer instanceof L.Rectangle) {
+        // (nvkelso 20240329: Test Rectangle before Polygon because of Leaflet bug)
+        layer.setStyle( options_label_bbox );
+        layer.bindPopup(popup_text_label_bbox);
+        count_rectangle++;
+        has_label_bbox = true;
+        updateDrawOptions();
+        // TODO: Add setting of WOF geometry
+        drawnItems.addLayer(layer);
+      } else if (layer instanceof L.Polygon) {
+        layer.setStyle( options_default_geom_polygon );
+        layer.bindPopup(popup_text_default_geom_polygon);
+        count_polygon++;
+        has_default_geom_polygon = true;
+        has_default_geom_point = false;
+        updateDrawOptions();
+        // TODO: Add setting of WOF geometry
+        // TODO: Will require moving the old default point geom to an alt (with new file), and source tracking
+        drawnItems.addLayer(layer);
+      }
+    });
+
+    map.on('draw:edited', function (e) {
+      var layers = e.layers;
+      layers.eachLayer(function (layer) {
+        if (layer.options && layer.options.title) {
+          console.log("Edited layer title:", layer.options.title);
+        }
+      });
+    });
     $("input.wof-input").on("change", function() {
         checkValid($(this));
+    });
+
+    // Add event listener to modify label_centroid when a marker is deleted
+    map.on('draw:deleted', function (e) {
+      var layers = e.layers;
+      layers.eachLayer(function (layer) {
+        if (layer instanceof L.CircleMarker) {
+          label_centroid = false;
+          count_circlemarker--;
+          updateDrawOptions();
+        }
+        if (layer.options && layer.options.title) {
+          console.log("Deleted layer title:", layer.options.title);
+        }
+      });
     });
 
     // Add dropdown list for languages
@@ -268,7 +492,7 @@ $(document).ready(function() {
         <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed.</small>
         <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
         {%- if wof_doc.properties['geom:area_square_m'] is defined %}
-        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code> is {{ wof_doc.properties['geom:area_square_m'] }} square meters)</small>
+        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code> is {{ wof_doc.properties['geom:area_square_m']|int }} square meters)</small>
         {%- else %}
         <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code>)</small>
         {%- endif %}

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -1,6 +1,6 @@
 {%- extends "_template.html" %}
 
-{%- block title %}{{ super() }} : Edit {{ wof_doc.properties['wof:name'] or woc_doc.id }}{%- endblock %}
+{%- block title %}{{ super() }} : Edit {{ wof_doc.properties['wof:name'] or woc_doc.id }} {%- endblock %}
 
 {%- block styles %}
 {{ super() }}
@@ -93,20 +93,11 @@ $(document).ready(function() {
     }).addTo(drawnItems);
     featureLayer.addData({{ {"type":"Feature","geometry":wof_doc.geometry}|tojson }});
     map.fitBounds(featureLayer.getBounds());
+    featureLayer.bindPopup("default geometry");
 
 	// Only enable polygon drawing if the default geom is a point not a polygon
     {% if wof_doc.geometry['type'] != 'Point' -%}
     enable_polygons = false;
-    {%- endif %}
-
-    {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
-    var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
-    var geomCentroidLayer = L.circleMarker(geomCentroid, {color: geomColors.geomCentroid, radius: 5, title: 'math centroid point'}).addTo(drawnItems);
-    {%- endif %}
-
-    {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
-    var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
-    var labelPointLayer = L.circleMarker(labelPoint, {color: geomColors.labelPoint, title: 'label point'}).addTo(drawnItems);
     {%- endif %}
 
     {%- if wof_doc.properties['lbl:bbox'] is defined %}
@@ -116,13 +107,27 @@ $(document).ready(function() {
         L.latLng({{ bboxParts[3] }}, {{ bboxParts[2] }}),
     );
     var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox, title: 'label bounding box'}).addTo(drawnItems);
+    labelBboxLayer.bindPopup("label bounding box");
 	// Disable drawing rectangles if the label bounding box already exists
     enable_rectangle = false;
+    {%- endif %}
+
+    {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
+    var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
+    var geomCentroidLayer = L.circleMarker(geomCentroid, {color: geomColors.geomCentroid, radius: 5, title: 'math centroid point'}).addTo(drawnItems);
+    geomCentroidLayer.bindPopup("math centroid point");
+    {%- endif %}
+
+    {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
+    var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
+    var labelPointLayer = L.circleMarker(labelPoint, {color: geomColors.labelPoint, title: 'label point'}).addTo(drawnItems);
+    labelPointLayer.bindPopup("label point");
     {%- endif %}
 
     {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
     var reverseGeo = L.latLng({{ wof_doc.properties['reversegeo:latitude']|float|tojson }}, {{ wof_doc.properties['reversegeo:longitude']|float|tojson }});
     var reverseGeoLayer = L.circleMarker(reverseGeo, {color: geomColors.revgeoPoint, title: 'reverse geocoding point'}).addTo(drawnItems);
+    reverseGeoLayer.bindPopup("reverse geocoding point");
     {%- endif %}
 
 	// Only enable circlemarker if no label centroid and no revgeo centroid
@@ -257,7 +262,8 @@ $(document).ready(function() {
 {%- endblock %}
 
 {%- block content %}
-<h3>Editing {{ wof_doc.properties['wof:name'] or wof_doc.id }}</h3><small>(<a href="https://spelunker.whosonfirst.org/id/{{ wof_doc.id }}/">View on Spelunker</a>)</small>
+<h3>Editing {{ wof_doc.properties['wof:name'] or wof_doc.id }}</h3>
+<small>(<a href="https://spelunker.whosonfirst.org/id/{{ wof_doc.id }}/">View on Spelunker</a>)</small>
 
 <div class="row col-md-12 mb-4">
     <div id="map"></div>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -62,13 +62,13 @@ $(document).ready(function() {
         maxZoom: 19
     }).addTo(map);
 
-	var drawnItems = new L.FeatureGroup();
-	map.addLayer(drawnItems);
+    var drawnItems = new L.FeatureGroup();
+    map.addLayer(drawnItems);
 
-	map.on('draw:created', function (e) {
-	  var layer = e.layer;
-	  drawnItems.addLayer(layer);
-	});
+    map.on('draw:created', function (e) {
+      var layer = e.layer;
+      drawnItems.addLayer(layer);
+    });
 
     var geomColors = {
         default: '#1f78b4',
@@ -95,7 +95,7 @@ $(document).ready(function() {
     map.fitBounds(featureLayer.getBounds());
     featureLayer.bindPopup("default geometry");
 
-	// Only enable polygon drawing if the default geom is a point not a polygon
+    // Only enable polygon drawing if the default geom is a point not a polygon
     {% if wof_doc.geometry['type'] != 'Point' -%}
     enable_polygons = false;
     {%- endif %}
@@ -108,7 +108,7 @@ $(document).ready(function() {
     );
     var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox, title: 'label bounding box'}).addTo(drawnItems);
     labelBboxLayer.bindPopup("label bounding box");
-	// Disable drawing rectangles if the label bounding box already exists
+    // Disable drawing rectangles if the label bounding box already exists
     enable_rectangle = false;
     {%- endif %}
 
@@ -130,35 +130,26 @@ $(document).ready(function() {
     reverseGeoLayer.bindPopup("reverse geocoding point");
     {%- endif %}
 
-	// Only enable circlemarker if no label centroid and no revgeo centroid
-    if( labelPoint && reverseGeo ) { enable_circlemarker = false; }
+    {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
+    enable_circlemarker = false;
+    {%- endif %}
 
-	var drawControl = new L.Control.Draw({
-	  position: 'topright',
-	  draw: {
-		polyline: false,    // Remove line drawing option
-		circle: false,
-		marker: false,
-		circlemarker: enable_circlemarker,
-		polygon: enable_polygons,
-		rectangle: enable_rectangle
-	  },
-	  edit: {
-		featureGroup: drawnItems
-	  }
-	});
-	map.addControl(drawControl);
+    var drawControl = new L.Control.Draw({
+      position: 'topright',
+      draw: {
+        polyline: false,    // Remove line drawing option
+        circle: false,
+        marker: false,
+        circlemarker: enable_circlemarker,
+        polygon: enable_polygons,
+        rectangle: enable_rectangle
+      },
+      edit: {
+        featureGroup: drawnItems
+      }
+    });
+    map.addControl(drawControl);
 
-
-	window.onload = onPageLoad();
-	
-	function onPageLoad() {
-	  if(featureLayer) { document.getElementById("geom_default").checked = true; }
-	  if(geomCentroidLayer) { document.getElementById("geom_math_centroid").checked = true; }
-	  if(labelPointLayer) { document.getElementById("geom_label_centroid").checked = true; }
-	  if(labelBboxLayer) { document.getElementById("geom_label_bounding_box").checked = true; }
-	  if(reverseGeoLayer) { document.getElementById("geom_revgeo_centroid").checked = true; }
-	}
 
     $("input.wof-input").on("change", function() {
         checkValid($(this));
@@ -273,27 +264,39 @@ $(document).ready(function() {
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
     <div class="form-group">
         <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. Alternate geometries are allowed.</small>
-        {%- if geomCentroidLayer %}
-        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom">
-        {%- else %}
-        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" checked=True>
-        {%- endif %}
+        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
         <label for="geom_default">Default geom</label>&nbsp;<small>(<code>geometry</code>)</small>
         
         <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
-        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid">
+        {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
+        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True checked=True>
+        {%- else %}
+        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True>
+        {%- endif %}
         <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom.longitude</code>, <code>geom.latitude</code>)</small>
 
         <small id="wof-name-help" class="form-text text-muted">The coordinate that specifies a label's east-west position (longitude) and north–south position (latitude). Human-generated or derived from mapshaper.</small>
-        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid">
+        {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
+        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True checked=True>
+        {%- else %}
+        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True>
+        {%- endif %}
         <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl.longitude</code>, <code>lbl.latitude</code>)</small>
 
         <small id="wof-name-help" class="form-text text-muted">The bounding box area used purely for map labelling and search purposes, and is usually smaller than the geom:bbox. Human-generated (not derived from Mapshaper).</small>
-        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box">
+        {%- if wof_doc.properties['lbl:bbox'] is defined %}
+        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True checked=True >
+        {%- else %}
+        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
+        {%- endif %}
         <label for="geom_label_bounding_box">Label bounding box</label>&nbsp;<small>(<code>lbl.bbox</code>)</small>
 
         <small id="wof-name-help" class="form-text text-muted">Typically derived from mapshaper, represents the centroid to use when reverse geocoding a record to establish the parent hierarchy.</small>
-        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid">
+        {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
+        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True checked=True >
+        {%- else %}
+        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>
+        {%- endif %}
         <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo.longitude</code>, <code>reversegeo.latitude</code>)</small>
     </div>
     <h4>Common properties</h4>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -354,12 +354,14 @@ $(document).ready(function() {
                   has_label_centroid = true;
                   layer.setStyle( options_label_centroid );
                   document.getElementById('geom_label_centroid').checked = true;
+                  document.getElementById('geom_label_centroid').disabled = false;
                   document.getElementById('geom_label_centroid_text').value = `${layer.getLatLng().lng.toFixed(6)},${layer.getLatLng().lat.toFixed(6)}`;
                   break;
                 case popup_text_revGeo_centroid: 
                   has_revGeo_centroid = true;
                   layer.setStyle(options_revGeo_centroid);
                   document.getElementById('geom_revgeo_centroid').checked = true;
+                  document.getElementById('geom_revgeo_centroid').disabled = false;
                   document.getElementById('geom_revgeo_centroid_text').value = `${layer.getLatLng().lng.toFixed(6)},${layer.getLatLng().lat.toFixed(6)}`;
                   break;
                 default:
@@ -367,7 +369,7 @@ $(document).ready(function() {
                   break;
               }
               
-              layer.options.title = labelType;
+              layer.title = labelType;
               layer.bindPopup(labelType);
 
               // TODO: Should block adding new circlemarkers until the dialog is submitted
@@ -392,8 +394,10 @@ $(document).ready(function() {
       } else if (shape == 'Rectangle') {
         // (nvkelso 20240329: Test Rectangle before Polygon because of Leaflet bug)
         layer.setStyle( options_label_bbox );
+        layer.title = popup_text_label_bbox;
         layer.bindPopup(popup_text_label_bbox);
         document.getElementById('geom_label_bounding_box').checked = true;
+        document.getElementById('geom_label_bounding_box').disabled = false;
         count_rectangle++;
         has_label_bbox = true;
         updateDrawOptions();
@@ -402,6 +406,7 @@ $(document).ready(function() {
         drawnItems.addLayer(layer);
       } else if (shape == 'Polygon') {
         layer.setStyle( options_default_geom_polygon );
+        layer.title = popup_text_default_geom_polygon;
         layer.bindPopup(popup_text_default_geom_polygon);
         document.getElementById('geom_default').checked = true;
         count_polygon++;
@@ -414,6 +419,60 @@ $(document).ready(function() {
         drawnItems.addLayer(layer);
       }
     });
+    
+    function removeLayer(whichLayer) {
+        // Loop through each layer on the map
+        map.eachLayer(function(layer) {
+            // Check if the layer has a 'title' property and if it is equal to "foo"
+            if (layer.options && layer.options.title === whichLayer) {
+                // Remove the layer from the map
+                map.removeLayer(layer);
+            }
+        });
+    }
+    
+    function updateLayer(whichLayer) {
+        if( whichLayer == popup_text_label_centroid || whichLayer == popup_text_revGeo_centroid) {
+          if( whichLayer == popup_text_label_centroid ) {
+            var inputLocation = document.getElementById('geom_label_centroid_text').value;
+          } else if( whichLayer == popup_text_revGeo_centroid ) {
+            var inputLocation = document.getElementById('geom_revgeo_centroid_text').value;
+          }
+        
+          // Split the input value on comma and parse latitude and longitude as floats
+          var newLocationArray = inputLocation.split(',');
+          var newLat = parseFloat(newLocationArray[1]);
+          var newLng = parseFloat(newLocationArray[0]);
+       
+          // Loop through each layer on the map
+          map.eachLayer(function(layer) {
+              // Check if the layer has a 'title' property and if it is equal to "foo"
+              if (layer.options && layer.options.title === whichLayer) {
+                  // Move the layer on the map
+                  layer.setLatLng([newLat, newLng]);
+              }
+          });
+        } else if( whichLayer == popup_text_label_bbox ) {
+//           var inputLocation = document.getElementById('geom_label_bounding_box_text').value;
+// 
+//           // Split the input value on comma and parse latitude and longitude as floats
+//           var bboxParts = inputLocation.split(',');
+//           
+//           var labelBbox2 = L.latLngBounds(
+//               L.latLng(parseFloat(bboxParts[1]), parseFloat(bboxParts[0])),
+//               L.latLng(parseFloat(bboxParts[3]), parseFloat(bboxParts[2]))
+//           );
+//        
+//           // Loop through each layer on the map
+//           map.eachLayer(function(layer) {
+//               // Check if the layer has a 'title' property and if it is equal to "foo"
+//               if (layer.options && layer.options.title === whichLayer) {
+//                   // Move the layer on the map
+//                   layer.setBounds(labelBbox2);
+//               }
+//           });
+        }
+    }
 
     // This happens on "save" of the editing session
     map.on('draw:edited', function (e) {
@@ -429,14 +488,41 @@ $(document).ready(function() {
         checkValid($(this));
     });
     
+    $("#geom_label_centroid").on("change", function(event) {
+        event.target.disabled = true;
+        document.getElementById('geom_label_centroid_text').value = '';
+        count_circlemarker--;
+        has_label_centroid = false;
+        updateDrawOptions();
+        removeLayer(popup_text_label_centroid);
+    });
     $("#geom_label_centroid_text").on("change", function(event) {
-        console.log('TODO: Add label centroid at: ', event.target.value);
+        console.log('TODO: Move label centroid to: ', event.target.value);
+        updateLayer(popup_text_label_centroid);
+    });
+    $("#geom_label_bounding_box").on("change", function(event) {
+        event.target.disabled = true;
+        document.getElementById('geom_label_bounding_box_text').value = '';
+        count_rectangle--;
+        has_label_bbox = false;
+        updateDrawOptions();
+        removeLayer(popup_text_label_bbox);
     });
     $("#geom_label_bounding_box_text").on("change", function(event) {
-        console.log('TODO: Add label bbox: ', event.target.value);
+        console.log('TODO: Move label bbox to: ', event.target.value);
+        updateLayer(popup_text_label_bbox);
+    });
+    $("#geom_revgeo_centroid").on("change", function(event) {
+        event.target.disabled = true;
+        document.getElementById('geom_revgeo_centroid_text').value = '';
+        count_circlemarker--;
+        has_revGeo_centroid = false;
+        updateDrawOptions();
+        removeLayer(popup_text_revGeo_centroid);
     });
     $("#geom_revgeo_centroid_text").on("change", function(event) {
-        console.log('TODO: Add revGeo centroid at: ', event.target.value);
+        console.log('TODO: Move revGeo centroid to: ', event.target.value);
+        updateLayer(popup_text_revGeo_centroid);
     });
     
 //     const inputElement = document.getElementById('geom_label_centroid');
@@ -651,7 +737,7 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {%- if wof_doc.properties['lbl:bbox'] is defined %}
-          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" checked=True >
+          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" checked=True>
           {%- else %}
           <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
           {%- endif %}
@@ -661,7 +747,7 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
-          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" checked=True >
+          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" checked=True>
           <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
           {%- else %}
           <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -575,7 +575,7 @@ $(document).ready(function() {
           <input type="checkbox" id="geom_math_centroid" name="geom_math_centroid" value="Geometric centroid" disabled=True>
           {%- endif %}
           <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom:longitude</code>, <code>geom:latitude</code>)</small>
-          <input disabled type="input" id="geom_math_centroid_text" name="geom:centroid" value="" class="form-control wof-input" data-wof-validation-regex="^([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+)$">
+          <input disabled type="input" id="geom_math_centroid_text" name="geom:centroid" value="" class="form-control wof-input">
           <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
       </div>
       <div class="form-group">

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -377,7 +377,7 @@ $(document).ready(function() {
         has_default_geom_point = false;
         updateDrawOptions();
         // needs to be after GUI setting
-        document.getElementById('geom_default_text').value = layer.toGeoJSON()["geometry"]["coordinates"];
+        document.getElementById('geom_default_text').value = JSON.stringify(layer.toGeoJSON()["geometry"]["coordinates"]);
         // TODO: Will require moving the old default point geom to an alt (with new file), and source tracking
         drawnItems.addLayer(layer);
       }

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -265,9 +265,27 @@ $(document).ready(function() {
     <h4>Geometries</h4>
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
     <div class="form-group">
-        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. Alternate geometries are allowed.</small>
+        {%- if wof_doc.properties['geom:area_square_m'] is defined %}
+        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. {{ wof_doc.properties['geom:area_square_m'] }} square meters</small>
+        {%- else %}
+        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed.</small>
+        {%- endif %}
         <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
-        <label for="geom_default">Default geom</label>&nbsp;<small>(<code>geometry</code>)</small>
+        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code>)</small>
+        {%- if wof_doc.properties['src:geom_alt'] is defined %}
+        <small id="wof-name-help" class="form-text text-muted">Alternate geometries are present from the following {{ wof_doc.properties['src:geom_alt']|length }} sources.</small>
+        <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True checked=True>
+        <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
+        {%- for alt_geom in wof_doc.properties['src:geom_alt'] %}
+        <ul class="form-text text-muted">
+            <li class="col-md-2 col-form-label">{{ alt_geom }}</li>
+        </ul>
+        {%- endfor %}
+        {%- else %}
+        <small id="wof-name-help" class="form-text text-muted">Alternate geometries are allowed (none present).</small>
+        <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True>
+        <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
+        {%- endif %}
         
         <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
         {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -1,6 +1,6 @@
 {%- extends "_template.html" %}
 
-{%- block title %}{{ super() }} : Edit {{ wof_doc.properties['wof:name'] or woc_doc.id }} {%- endblock %}
+{%- block title %}{{ super() }} : Edit {{ wof_doc.properties['wof:name'] or woc_doc.id }}{%- endblock %}
 
 {%- block styles %}
 {{ super() }}
@@ -262,8 +262,7 @@ $(document).ready(function() {
 {%- endblock %}
 
 {%- block content %}
-<h3>Editing {{ wof_doc.properties['wof:name'] or wof_doc.id }}</h3>
-<small>(<a href="https://spelunker.whosonfirst.org/id/{{ wof_doc.id }}/">View on Spelunker</a>)</small>
+<h3>Editing {{ wof_doc.properties['wof:name'] or wof_doc.id }}</h3><small>(<a href="https://spelunker.whosonfirst.org/id/{{ wof_doc.id }}/">View on Spelunker</a>)</small>
 
 <div class="row col-md-12 mb-4">
     <div id="map"></div>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -107,6 +107,8 @@ $(document).ready(function() {
     var z_offset_label_bbox = 1;
     var z_offset_revGeo_centroid = 1;
     
+    $("#geometries_section").collapse();
+    
     function drawGeoms() {
       count_circlemarker = 0;
       count_polygon = 0;
@@ -133,7 +135,8 @@ $(document).ready(function() {
       map.fitBounds(featureLayer.getBounds());
       // TODO: This is more complicated, depending on Polygon or Point we'd update text, too
       document.getElementById('geom_default').checked = true;
-    
+      document.getElementById('geom_default_text').value = "{{ wof_doc.geometry['coordinates'] }}";
+
       // Only enable polygon drawing if the default geom is a point not a polygon
       {% if wof_doc.geometry['type'] != 'Point' -%}
       featureLayer.bindPopup(popup_text_default_geom_polygon);
@@ -158,6 +161,7 @@ $(document).ready(function() {
       count_rectangle++;
       has_label_bbox = true;
       document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
+      document.getElementById('geom_label_bounding_box_text').value = "{{ wof_doc.properties['lbl:bbox'] }}";
       {%- endif %}
 
       {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
@@ -167,7 +171,8 @@ $(document).ready(function() {
       // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
       drawnItems.addLayer(geomCentroidLayer);
       has_math_centroid = true;
-      document.getElementById('geom_centroid').checked = has_math_centroid;
+      document.getElementById('geom_math_centroid').checked = has_math_centroid;
+      document.getElementById('geom_math_centroid_text').value = "{{ wof_doc.properties['geom:longitude'] }}, {{ wof_doc.properties['geom:latitude'] }}";
       {%- endif %}
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
@@ -179,6 +184,7 @@ $(document).ready(function() {
       count_circlemarker++;
       has_label_centroid = true;
       document.getElementById('geom_label_centroid').checked = has_label_centroid;
+      document.getElementById('geom_label_centroid_text').value = "{{ wof_doc.properties['lbl:longitude'] }}, {{ wof_doc.properties['lbl:latitude'] }}";
       {%- endif %}
 
       {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
@@ -190,6 +196,7 @@ $(document).ready(function() {
       count_circlemarker++;
       has_revGeo_centroid = true;
       document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
+      document.getElementById('geom_revgeo_centroid_text').value = "{{ wof_doc.properties['reversegeo:longitude'] }}, {{ wof_doc.properties['reversegeo:latitude'] }}";
       {%- endif %}
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
@@ -255,11 +262,6 @@ $(document).ready(function() {
       // to work around bug in the Leaflet Draw plugin, remove it and add it back for new options to take effect
       map.removeControl(drawControl);
       map.addControl(drawControl);
-      
-      document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
-      document.getElementById('geom_label_bounding_box_text').value = "{{ wof_doc.properties['lbl:bbox'] }}";
-      document.getElementById('geom_label_centroid').checked = has_label_centroid;
-      document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
     }
 
     map.on('draw:created', function (e) {
@@ -310,13 +312,13 @@ $(document).ready(function() {
                   has_label_centroid = true;
                   layer.setStyle( options_label_centroid );
                   document.getElementById('geom_label_centroid').checked = true;
-                  // TODO: Add setting of WOF geometry
+                  document.getElementById('geom_label_centroid_text').value = `${layer.getLatLng().lng.toFixed(6)},${layer.getLatLng().lat.toFixed(6)}`;
                   break;
                 case popup_text_revGeo_centroid: 
                   has_revGeo_centroid = true;
                   layer.setStyle(options_revGeo_centroid);
                   document.getElementById('geom_revgeo_centroid').checked = true;
-                  // TODO: Add setting of WOF geometry
+                  document.getElementById('geom_revgeo_centroid_text').value = `${layer.getLatLng().lng.toFixed(6)},${layer.getLatLng().lat.toFixed(6)}`;
                   break;
                 default:
                   //console.log( labelType );
@@ -353,6 +355,7 @@ $(document).ready(function() {
         count_rectangle++;
         has_label_bbox = true;
         updateDrawOptions();
+        // needs to be after GUI setting
         document.getElementById('geom_label_bounding_box_text').value = `${layer.getBounds().getWest().toFixed(6)},${layer.getBounds().getSouth().toFixed(6)},${layer.getBounds().getEast().toFixed(6)},${layer.getBounds().getNorth().toFixed(6)}`;
         drawnItems.addLayer(layer);
       } else if (layer instanceof L.Polygon) {
@@ -363,7 +366,8 @@ $(document).ready(function() {
         has_default_geom_polygon = true;
         has_default_geom_point = false;
         updateDrawOptions();
-        // TODO: Add setting of WOF geometry
+        // needs to be after GUI setting
+        document.getElementById('geom_default_text').value = layer.toGeoJSON()["geometry"]["coordinates"];
         // TODO: Will require moving the old default point geom to an alt (with new file), and source tracking
         drawnItems.addLayer(layer);
       }
@@ -487,15 +491,15 @@ $(document).ready(function() {
     // Default to showing English only
     $("#localized-labels-selected").data("tagify").addTags([{"lang": "eng", "value": "English (eng)"}]);
 
-    // Toggle show/hide of geometries section
-    $("#show-hide-geoms").on("click", function(e) {
-      var x = document.getElementById("geometries_section");
-      if (x.style.display === "none") {
-        x.style.display = "block";
-      } else {
-        x.style.display = "none";
-      }
-    });
+    // // Toggle show/hide of geometries section
+//     $("#show-hide-geoms").on("click", function(e) {
+//       var x = document.getElementById("geometries_section");
+//       if (x.style.display === "none") {
+//         x.style.display = "block";
+//       } else {
+//         x.style.display = "none";
+//       }
+//     });
 
     // Perform validation before submitting form
     $("button[name=\"next-step\"]").on("click", function(e) {
@@ -522,11 +526,6 @@ $(document).ready(function() {
         newRow.find('input[name="new-wof:concordances-value"]').attr("name", "new-wof:concordances-value" + $(".concordance-row").length);
         newRow.show();
     });
-    
-    // TODO: This doesn't work
-    $(document).ready(function(){
-      $("#geometries_section").collapse();
-    });
 });
 </script>
 {%- endblock %}
@@ -550,7 +549,7 @@ $(document).ready(function() {
           {%- else %}
           <label for="geom_default">Default geometry</label>&nbsp;<small>({{ wof_doc.geometry['type'] }} <code>geometry["coordinates"]</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code>)</small>
           {%- endif %}
-          <input type="input" id="geom_default_text" name="geom:coordinates" value="{{ wof_doc.geometry['coordinates'] }}" class="form-control wof-input">
+          <input type="input" id="geom_default_text" name="geom:coordinates" value="" class="form-control wof-input">
           <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. If water is included, please add a land-based reverse geocoding centroid.</small>
       </div>
       <div class="form-group">
@@ -571,24 +570,23 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
-          <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True checked=True>
+          <input type="checkbox" id="geom_math_centroid" name="geom_math_centroid" value="Geometric centroid" disabled=True checked=True>
           {%- else %}
-          <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True>
+          <input type="checkbox" id="geom_math_centroid" name="geom_math_centroid" value="Geometric centroid" disabled=True>
           {%- endif %}
           <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom:longitude</code>, <code>geom:latitude</code>)</small>
-          <input disabled type="input" id="geom_math_centroid_text" name="geom:centroid" value="{{ wof_doc.properties['geom:longitude'] }}, {{ wof_doc.properties['geom:latitude'] }}" class="form-control wof-input">
+          <input disabled type="input" id="geom_math_centroid_text" name="geom:centroid" value="" class="form-control wof-input" data-wof-validation-regex="^([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+)$">
           <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
       </div>
       <div class="form-group">
           {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
           <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True checked=True>
           <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl:longitude</code>, <code>lbl:latitude</code>)</small>
-          <input type="input" id="geom_label_centroid_text" name="lbl:centroid" value="{{ wof_doc.properties['lbl:longitude'] }}, {{ wof_doc.properties['lbl:latitude'] }}" class="form-control wof-input">
           {%- else %}
           <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True>
           <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl:longitude</code>, <code>lbl:latitude</code>)</small>
-          <input type="input" id="geom_label_centroid_text" name="lbl:centroid" value="" class="form-control wof-input">
           {%- endif %}
+          <input type="input" id="geom_label_centroid_text" name="lbl:centroid" value="" class="form-control wof-input" data-wof-validation-regex="^([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+)$">
           <small id="wof-name-help" class="form-text text-muted">The coordinate that specifies a label's east-west position (longitude) and north–south position (latitude). Human-generated or derived from mapshaper.</small>
       </div>
       <div class="form-group">
@@ -598,19 +596,18 @@ $(document).ready(function() {
           <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
           {%- endif %}
           <label for="geom_label_bounding_box">Label bounding box</label>&nbsp;<small>(<code>lbl:bbox</code>)</small>
-          <input type="input" id="geom_label_bounding_box_text" name="lbl:bbox" value="{{ wof_doc.properties['lbl:bbox'] }}" class="form-control wof-input">
+          <input type="input" id="geom_label_bounding_box_text" name="lbl:bbox" value="{{ wof_doc.properties['lbl:bbox'] }}" class="form-control wof-input" data-wof-validation-regex="^([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+)$">
           <small id="wof-name-help" class="form-text text-muted">Used for map viewports and search. Usually smaller than the geom:bbox for polygons but larger for points. Human-generated.</small>
       </div>
       <div class="form-group">
           {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
           <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True checked=True >
           <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
-          <input type="input" id="geom_label_centroid_text" name="reversegeo:centroid" value="{{ wof_doc.properties['reversegeo:longitude'] }}, {{ wof_doc.properties['reversegeo:latitude'] }}" class="form-control wof-input">
           {%- else %}
           <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>
           <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
-          <input type="input" id="geom_label_centroid_text" name="reversegeo:centroid" value="" class="form-control wof-input">
           {%- endif %}
+          <input type="input" id="geom_revgeo_centroid_text" name="reversegeo:centroid" value="" class="form-control wof-input" data-wof-validation-regex="^([-+]?[0-9]*\.?\d+),\s*([-+]?[0-9]*\.?\d+)$">
           <small id="wof-name-help" class="form-text text-muted">Represents the centroid to use when reverse geocoding a record to establish the parent hierarchy, preferably on land. Typically derived from mapshaper.</small>
       </div>
     </div>
@@ -648,7 +645,7 @@ $(document).ready(function() {
     </div>
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/mz/is_funky.json -->
     <div class="form-group">
-        <label for="mz-is_funky">Disabled</label>&nbsp;<small>(<code>mz:is_funky</code>)</small>
+        <label for="mz-is_funky">Disabled</label>&nbsp;<small>(<code>mz:is_funky</code>)</small> 
         <input type="text" class="form-control wof-input" name="mz:is_funky" data-wof-validation-regex="^(-1|0|1)$" value="{{ wof_doc.properties['mz:is_funky'] }}">
         <small id="mz-is_funky-help" class="form-text text-muted">Used when Mapzen suspects the record is bad or inappropriate but additional confirmation is needed before the feature is deprecated. Records with a 1 value are recommended to be hidden from map display and search unless explicitly asked for by name.</small>
     </div>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -106,7 +106,7 @@ $(document).ready(function() {
     var z_offset_label_centroid = 2;
     var z_offset_label_bbox = 1;
     var z_offset_revGeo_centroid = 1;
-
+    
     function drawGeoms() {
       count_circlemarker = 0;
       count_polygon = 0;
@@ -487,6 +487,16 @@ $(document).ready(function() {
     // Default to showing English only
     $("#localized-labels-selected").data("tagify").addTags([{"lang": "eng", "value": "English (eng)"}]);
 
+    // Toggle show/hide of geometries section
+    $("#show-hide-geoms").on("click", function(e) {
+      var x = document.getElementById("geometries_section");
+      if (x.style.display === "none") {
+        x.style.display = "block";
+      } else {
+        x.style.display = "none";
+      }
+    });
+
     // Perform validation before submitting form
     $("button[name=\"next-step\"]").on("click", function(e) {
         var anyFieldsInvalid = $("input.wof-input").toArray().some(function(eachElem, i) {
@@ -512,6 +522,11 @@ $(document).ready(function() {
         newRow.find('input[name="new-wof:concordances-value"]').attr("name", "new-wof:concordances-value" + $(".concordance-row").length);
         newRow.show();
     });
+    
+    // TODO: This doesn't work
+    $(document).ready(function(){
+      $("#geometries_section").collapse();
+    });
 });
 </script>
 {%- endblock %}
@@ -525,62 +540,81 @@ $(document).ready(function() {
 
 <form class="needs-validation" novalidate action="{{ url_for('place.edit_place', url=wof_url) }}" method="POST">
     <h4>Geometries</h4>
-    <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
-    <div class="form-group">
-        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed.</small>
-        <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
-        {%- if wof_doc.properties['geom:area_square_m'] is defined %}
-        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code> is {{ wof_doc.properties['geom:area_square_m']|int }} square meters)</small>
-        {%- else %}
-        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code>)</small>
-        {%- endif %}
-        {%- if wof_doc.properties['src:geom_alt'] is defined %}
-        <small id="wof-name-help" class="form-text text-muted">Alternate geometries are present from the following {{ wof_doc.properties['src:geom_alt']|length }} sources.</small>
-        <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True checked=True>
-        <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
-        {%- for alt_geom in wof_doc.properties['src:geom_alt'] %}
-        <ul class="form-text text-muted">
-            <li><code>{{ alt_geom }}</code></li>
-        </ul>
-        {%- endfor %}
-        {%- else %}
-        <small id="wof-name-help" class="form-text text-muted">Alternate geometries are allowed (none present).</small>
-        <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True>
-        <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
-        {%- endif %}
-        
-        <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
-        {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
-        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True checked=True>
-        {%- else %}
-        <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True>
-        {%- endif %}
-        <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom.longitude</code>, <code>geom.latitude</code>)</small>
-
-        <small id="wof-name-help" class="form-text text-muted">The coordinate that specifies a label's east-west position (longitude) and north–south position (latitude). Human-generated or derived from mapshaper.</small>
-        {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
-        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True checked=True>
-        {%- else %}
-        <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True>
-        {%- endif %}
-        <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl.longitude</code>, <code>lbl.latitude</code>)</small>
-
-        <small id="wof-name-help" class="form-text text-muted">The bounding box area used purely for map labelling and search purposes, and is usually smaller than the geom:bbox. Human-generated (not derived from Mapshaper).</small>
-        {%- if wof_doc.properties['lbl:bbox'] is defined %}
-        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True checked=True >
-        {%- else %}
-        <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
-        {%- endif %}
-        <label for="geom_label_bounding_box">Label bounding box</label>&nbsp;<small>(<code>lbl.bbox</code>)</small>
-
-        <small id="wof-name-help" class="form-text text-muted">Typically derived from mapshaper, represents the centroid to use when reverse geocoding a record to establish the parent hierarchy.</small>
-        {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
-        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True checked=True >
-        {%- else %}
-        <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>
-        {%- endif %}
-        <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo.longitude</code>, <code>reversegeo.latitude</code>)</small>
+    <!-- TODO: This doesn't show/hide -->
+    <!-- <button id="show-hide-geoms" class="btn btn-secondary">Hide geometries</button> -->
+    <div id="geometries_section" class="geometries_section">
+      <div class="form-group">
+          <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
+          {%- if wof_doc.properties['geom:area_square_m'] is defined %}
+          <label for="geom_default">Default geometry</label>&nbsp;<small>({{ wof_doc.geometry['type'] }} <code>geometry["coordinates"]</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code> is {{ wof_doc.properties['geom:area_square_m']|int }} square meters)</small>
+          {%- else %}
+          <label for="geom_default">Default geometry</label>&nbsp;<small>({{ wof_doc.geometry['type'] }} <code>geometry["coordinates"]</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code>)</small>
+          {%- endif %}
+          <input type="input" id="geom_default_text" name="geom:coordinates" value="{{ wof_doc.geometry['coordinates'] }}" class="form-control wof-input">
+          <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. If water is included, please add a land-based reverse geocoding centroid.</small>
+      </div>
+      <div class="form-group">
+          {%- if wof_doc.properties['src:geom_alt'] is defined %}
+          <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True checked=True>
+          <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
+          <small id="wof-name-help" class="form-text text-muted">Alternate geometries are present from the following {{ wof_doc.properties['src:geom_alt']|length }} sources:</small>
+          {%- for alt_geom in wof_doc.properties['src:geom_alt'] %}
+          <ul class="form-text text-muted">
+              <li><code>{{ alt_geom }}</code></li>
+          </ul>
+          {%- endfor %}
+          {%- else %}
+          <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True>
+          <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
+          <small id="wof-name-help" class="form-text text-muted">Alternate geometries are allowed (none present).</small>
+          {%- endif %}
+      </div>
+      <div class="form-group">
+          {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
+          <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True checked=True>
+          {%- else %}
+          <input type="checkbox" id="geom_centroid" name="geom_centroid" value="Geometric centroid" disabled=True>
+          {%- endif %}
+          <label for="geom_math_centroid">Math centroid</label>&nbsp;<small>(<code>geom:longitude</code>, <code>geom:latitude</code>)</small>
+          <input disabled type="input" id="geom_math_centroid_text" name="geom:centroid" value="{{ wof_doc.properties['geom:longitude'] }}, {{ wof_doc.properties['geom:latitude'] }}" class="form-control wof-input">
+          <small id="wof-name-help" class="form-text text-muted">The location of a feature's geometric centroid (can be off the surface). Machine generated.</small>
+      </div>
+      <div class="form-group">
+          {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
+          <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True checked=True>
+          <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl:longitude</code>, <code>lbl:latitude</code>)</small>
+          <input type="input" id="geom_label_centroid_text" name="lbl:centroid" value="{{ wof_doc.properties['lbl:longitude'] }}, {{ wof_doc.properties['lbl:latitude'] }}" class="form-control wof-input">
+          {%- else %}
+          <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True>
+          <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl:longitude</code>, <code>lbl:latitude</code>)</small>
+          <input type="input" id="geom_label_centroid_text" name="lbl:centroid" value="" class="form-control wof-input">
+          {%- endif %}
+          <small id="wof-name-help" class="form-text text-muted">The coordinate that specifies a label's east-west position (longitude) and north–south position (latitude). Human-generated or derived from mapshaper.</small>
+      </div>
+      <div class="form-group">
+          {%- if wof_doc.properties['lbl:bbox'] is defined %}
+          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True checked=True >
+          {%- else %}
+          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
+          {%- endif %}
+          <label for="geom_label_bounding_box">Label bounding box</label>&nbsp;<small>(<code>lbl:bbox</code>)</small>
+          <input type="input" id="geom_label_bounding_box_text" name="lbl:bbox" value="{{ wof_doc.properties['lbl:bbox'] }}" class="form-control wof-input">
+          <small id="wof-name-help" class="form-text text-muted">Used for map viewports and search. Usually smaller than the geom:bbox for polygons but larger for points. Human-generated.</small>
+      </div>
+      <div class="form-group">
+          {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
+          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True checked=True >
+          <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
+          <input type="input" id="geom_label_centroid_text" name="reversegeo:centroid" value="{{ wof_doc.properties['reversegeo:longitude'] }}, {{ wof_doc.properties['reversegeo:latitude'] }}" class="form-control wof-input">
+          {%- else %}
+          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>
+          <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
+          <input type="input" id="geom_label_centroid_text" name="reversegeo:centroid" value="" class="form-control wof-input">
+          {%- endif %}
+          <small id="wof-name-help" class="form-text text-muted">Represents the centroid to use when reverse geocoding a record to establish the parent hierarchy, preferably on land. Typically derived from mapshaper.</small>
+      </div>
     </div>
+
     <h4>Common properties</h4>
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
     <div class="form-group">

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -257,6 +257,7 @@ $(document).ready(function() {
       map.addControl(drawControl);
       
       document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
+      document.getElementById('geom_label_bounding_box_text').value = "{{ wof_doc.properties['lbl:bbox'] }}";
       document.getElementById('geom_label_centroid').checked = has_label_centroid;
       document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
     }
@@ -352,7 +353,7 @@ $(document).ready(function() {
         count_rectangle++;
         has_label_bbox = true;
         updateDrawOptions();
-        // TODO: Add setting of WOF geometry
+        document.getElementById('geom_label_bounding_box_text').value = `${layer.getBounds().getWest().toFixed(6)},${layer.getBounds().getSouth().toFixed(6)},${layer.getBounds().getEast().toFixed(6)},${layer.getBounds().getNorth().toFixed(6)}`;
         drawnItems.addLayer(layer);
       } else if (layer instanceof L.Polygon) {
         layer.setStyle( options_default_geom_polygon );

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -269,46 +269,47 @@ $(document).ready(function() {
     // Create an instance of the custom control and add it to the map
     new ResetButton({ position: 'topright' }).addTo(map);
 
-    // add Leaflet-Geoman controls with some options to the map  
-    var drawControl = map.pm.addControls({  
-      position: 'topright',  
-      drawPolyline: false,    // Remove line drawing option
-      drawCircle: false,
-      drawMarker: false,
-      drawText: false,
-      cutPolygon: false,
-      drawCirclemarker: enable_circlemarker,
-      drawPolygon: enable_polygon,
-      drawRectangle: enable_rectangle
-    });
+    // add Leaflet-Geoman controls with some options to the map
+    function addDrawControls() {
+      var drawControl = map.pm.addControls({  
+        position: 'topright',  
+        drawPolyline: false,    // Remove line drawing option
+        drawCircle: false,
+        drawMarker: false,
+        drawText: false,
+        cutPolygon: false,
+        drawCircleMarker: enable_circlemarker,
+        drawPolygon: enable_polygon,
+        drawRectangle: enable_rectangle
+      });
+    }
     
     function updateDrawOptions() {
+      map.pm.disableDraw();
       if( count_circlemarker >= 2 ) {
-        map.pm.setGlobalOptions({drawCirclemarker: false});
+        enable_circlemarker = false;
       } else {
-        map.pm.setGlobalOptions({drawCirclemarker: true});
+        enable_circlemarker = true;
       }
       if( count_polygon >= 1 ) {
-        map.pm.setGlobalOptions({drawPolygon: false});
+        enable_polygon = false;
       } else {
-        map.pm.setGlobalOptions({drawPolygon: true});
+        enable_polygon = true;
       }
       if( count_rectangle >= 1 ) {
-        map.pm.setGlobalOptions({drawRectangle: false});
+        enable_rectangle = false;
       } else {
-        map.pm.setGlobalOptions({drawRectangle: true});
+        enable_rectangle = true;
       }
-      // to work around bug in the Leaflet Draw plugin, remove it and add it back for new options to take effect
-      map.removeControl(drawControl);
-      map.addControl(drawControl);
+      map.pm.removeControls();
+      addDrawControls();
     }
 
+    updateDrawOptions();
+    
     map.on('pm:create', function (e) {
       var layer = e.layer;
       var shape = e.shape;
-      
-      console.log(layer);
-      console.log(shape);
       
       if (shape == 'CircleMarker') {
         if (count_circlemarker>=2) {
@@ -316,8 +317,6 @@ $(document).ready(function() {
           return;
         }
         circleMarkerAdded = true;
-        drawControl.setDrawingOptions({ marker: false }); // Disable marker drawing option
-        
         count_circlemarker++;
         updateDrawOptions();
 

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -160,9 +160,9 @@ $(document).ready(function() {
       enable_rectangle = false;
       count_rectangle++;
       has_label_bbox = true;
+      {%- endif %}
       document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
       document.getElementById('geom_label_bounding_box_text').value = "{{ wof_doc.properties['lbl:bbox'] }}";
-      {%- endif %}
 
       {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
       var geomCentroid = L.latLng({{ wof_doc.properties['geom:latitude']|float|tojson }}, {{ wof_doc.properties['geom:longitude']|float|tojson }});
@@ -171,9 +171,11 @@ $(document).ready(function() {
       // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
       drawnItems.addLayer(geomCentroidLayer);
       has_math_centroid = true;
-      document.getElementById('geom_math_centroid').checked = has_math_centroid;
       document.getElementById('geom_math_centroid_text').value = "{{ wof_doc.properties['geom:longitude'] }}, {{ wof_doc.properties['geom:latitude'] }}";
+      {%- else %}
+      document.getElementById('geom_math_centroid_text').value = "";
       {%- endif %}
+      document.getElementById('geom_math_centroid').checked = has_math_centroid;
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
       var labelPoint = L.latLng({{ wof_doc.properties['lbl:latitude']|float|tojson }}, {{ wof_doc.properties['lbl:longitude']|float|tojson }});
@@ -183,9 +185,11 @@ $(document).ready(function() {
       drawnItems.addLayer(labelPointLayer);
       count_circlemarker++;
       has_label_centroid = true;
-      document.getElementById('geom_label_centroid').checked = has_label_centroid;
       document.getElementById('geom_label_centroid_text').value = "{{ wof_doc.properties['lbl:longitude'] }}, {{ wof_doc.properties['lbl:latitude'] }}";
+      {%- else %}
+      document.getElementById('geom_label_centroid_text').value = "";
       {%- endif %}
+      document.getElementById('geom_label_centroid').checked = has_label_centroid;
 
       {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
       var reverseGeo = L.latLng({{ wof_doc.properties['reversegeo:latitude']|float|tojson }}, {{ wof_doc.properties['reversegeo:longitude']|float|tojson }});
@@ -195,9 +199,11 @@ $(document).ready(function() {
       drawnItems.addLayer(reverseGeoLayer);
       count_circlemarker++;
       has_revGeo_centroid = true;
-      document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
       document.getElementById('geom_revgeo_centroid_text').value = "{{ wof_doc.properties['reversegeo:longitude'] }}, {{ wof_doc.properties['reversegeo:latitude'] }}";
+      {%- else %}
+      document.getElementById('geom_revgeo_centroid_text').value = "";
       {%- endif %}
+      document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
       enable_circlemarker = false;

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -5,7 +5,7 @@
 {%- block styles %}
 {{ super() }}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
-<link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" integrity="sha384-NZLkVuBRMEeB4VeZz27WwTRvlhec30biQ8Xx7zG7JJnkvEKRg5qi6BNbEXo9ydwv"" crossorigin=""/>
 <link rel="stylesheet" href="https://unpkg.com/@yaireo/tagify@2.31.6/dist/tagify.css" integrity="sha384-VgQsYt/GtydzxrFEKS4D9VXB6lLQ4cXbFwdorV5HIkxXY8N9e1gJCl36seX6wYYP" crossorigin=""/>
 <style type="text/css">
     #map {
@@ -20,7 +20,7 @@
 {{ super() }}
 <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js" integrity="sha384-sKs8ZrrxyJoElcPVznZwGpUTTXvkMYfHYxdIFzO8Hd0TA6emONMj8BwnsFf+6cZ/" crossorigin=""></script>
-<script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>
+<script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js" integrity="ha384-JP5UPxIO2Tm2o79Fb0tGYMa44jkWar53aBoCbd8ah0+LcCDoohTIYr+zIXyfGIJN" crossorigin=""></script>
 <script src="https://unpkg.com/@yaireo/tagify@2.31.6/dist/jQuery.tagify.min.js" integrity="sha384-oJRpUI+TNL56khhVpM5tcGH6Al77rv1qUUKXqmG0cMe5KtcNzLYfxgdcwunFouVe" crossorigin=""></script>
 <script type="text/javascript">
 $(document).ready(function() {
@@ -265,20 +265,20 @@ $(document).ready(function() {
     <h4>Geometries</h4>
     <!-- https://github.com/whosonfirst/whosonfirst-properties/blob/master/properties/wof/name.json -->
     <div class="form-group">
-        {%- if wof_doc.properties['geom:area_square_m'] is defined %}
-        <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed. {{ wof_doc.properties['geom:area_square_m'] }} square meters</small>
-        {%- else %}
         <small id="wof-name-help" class="form-text text-muted">Land-only multi-polygons are preferred, points are allowed.</small>
-        {%- endif %}
         <input type="checkbox" id="geom_default" name="geom_default" value="Default geom" disabled=True checked=True>
-        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code>)</small>
+        {%- if wof_doc.properties['geom:area_square_m'] is defined %}
+        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code> is {{ wof_doc.properties['geom:area_square_m'] }} square meters)</small>
+        {%- else %}
+        <label for="geom_default">Default geometry</label>&nbsp;<small>(<code>geometry</code> sourced from <code>{{ wof_doc.properties['src:geom'] }}</code>)</small>
+        {%- endif %}
         {%- if wof_doc.properties['src:geom_alt'] is defined %}
         <small id="wof-name-help" class="form-text text-muted">Alternate geometries are present from the following {{ wof_doc.properties['src:geom_alt']|length }} sources.</small>
         <input type="checkbox" id="geom_alternates" name="geom_alternates" value="Alternate geometries" disabled=True checked=True>
         <label for="geom_default">Alternate geometries</label>&nbsp;<small>(<code>src:geom_alt</code>)</small>
         {%- for alt_geom in wof_doc.properties['src:geom_alt'] %}
         <ul class="form-text text-muted">
-            <li class="col-md-2 col-form-label">{{ alt_geom }}</li>
+            <li><code>{{ alt_geom }}</code></li>
         </ul>
         {%- endfor %}
         {%- else %}

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -390,6 +390,22 @@ $(document).ready(function() {
     $("input.wof-input").on("change", function() {
         checkValid($(this));
     });
+    
+    $("#geom_label_centroid_text").on("change", function(event) {
+        console.log('TODO: Add label centroid at: ', event.target.value);
+    });
+    $("#geom_label_bounding_box_text").on("change", function(event) {
+        console.log('TODO: Add label bbox: ', event.target.value);
+    });
+    $("#geom_revgeo_centroid_text").on("change", function(event) {
+        console.log('TODO: Add revGeo centroid at: ', event.target.value);
+    });
+    
+//     const inputElement = document.getElementById('geom_label_centroid');
+//     inputElement.addEventListener('change', function(event) {
+//       // Log the new value to the console
+//       console.log('New value:', event.target.value);
+//     });
 
     // Add event listener to modify label_centroid when a marker is deleted
     map.on('draw:deleted', function (e) {
@@ -586,7 +602,7 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
-          <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True checked=True>
+          <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" checked=True>
           <label for="geom_label_centroid">Label centroid</label>&nbsp;<small>(<code>lbl:longitude</code>, <code>lbl:latitude</code>)</small>
           {%- else %}
           <input type="checkbox" id="geom_label_centroid" name="geom_label_centroid" value="Label centroid" disabled=True>
@@ -597,7 +613,7 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {%- if wof_doc.properties['lbl:bbox'] is defined %}
-          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True checked=True >
+          <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" checked=True >
           {%- else %}
           <input type="checkbox" id="geom_label_bounding_box" name="geom_label_bounding_box" value="Label bounding box" disabled=True>
           {%- endif %}
@@ -607,7 +623,7 @@ $(document).ready(function() {
       </div>
       <div class="form-group">
           {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
-          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True checked=True >
+          <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" checked=True >
           <label for="geom_label_centroid">Reverse geocoding centroid</label>&nbsp;<small>(<code>reversegeo:longitude</code>, <code>reversegeo:latitude</code>)</small>
           {%- else %}
           <input type="checkbox" id="geom_revgeo_centroid" name="geom_revgeo_centroid" value="Reverse geocoding centroid" disabled=True>

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -383,17 +383,17 @@ $(document).ready(function() {
 
     // Add dropdown list for languages
     $('input.wof-input[name="wof:lang_x_spoken"]').tagify({
-        whitelist: {{ lang_expansion.keys()|list|tojson }},
+        allowlist: {{ lang_expansion.keys()|list|tojson }},
     });
     $('input.wof-input[name="wof:lang_x_official"]').tagify({
-        whitelist: {{ lang_expansion.keys()|list|tojson }},
+        allowlist: {{ lang_expansion.keys()|list|tojson }},
     });
     $('input.wof-input[name="wof:placetype_alt"]').tagify();
     $(".use-tagify").tagify({delimiters: null});
 
     // Set up a filter to pick which languages to show
     $("#alternate-names-selected").tagify({
-        whitelist: {{ localized_names_tagify_whitelist|tojson }},
+        allowlist: {{ localized_names_tagify_allowlist|tojson }},
     }).on("add", function(e, tag) {
         var lang = tag.data.lang || tag.data.value;
         var existing = $(".localized-names-row[data-lang=\"" + lang + "\"]").first()
@@ -422,7 +422,7 @@ $(document).ready(function() {
 
     // Set up a filter to pick which languages to show
     $("#localized-labels-selected").tagify({
-        whitelist: {{ localized_labels_tagify_whitelist|tojson }},
+        allowlist: {{ localized_labels_tagify_allowlist|tojson }},
     }).on("add", function(e, tag) {
         var lang = tag.data.lang || tag.data.value;
         var existing = $(".localized-labels-row[data-lang=\"" + lang + "\"]").first()

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -5,7 +5,10 @@
 {%- block styles %}
 {{ super() }}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
+<!-- 
 <link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" integrity="sha384-NZLkVuBRMEeB4VeZz27WwTRvlhec30biQ8Xx7zG7JJnkvEKRg5qi6BNbEXo9ydwv"" crossorigin=""/>
+ -->
+<link rel="stylesheet" href="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.css" integrity="sha384-kFHJXoxnyoGXzCN/jBWXbLGVLIsjMOz3OflpKpSJorRSOY++lYGPt8VoHurVr94q" crossorigin=""/>
 <link rel="stylesheet" href="https://unpkg.com/@yaireo/tagify@2.31.6/dist/tagify.css" integrity="sha384-VgQsYt/GtydzxrFEKS4D9VXB6lLQ4cXbFwdorV5HIkxXY8N9e1gJCl36seX6wYYP" crossorigin=""/>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@v0.79.0/dist/L.Control.Locate.min.css" integrity="sha384-s1weW3rLvQEcQo1OenCYWESkNoaaT6C995dZ4jgUAt+qkjhTNQoN8mhu6ZwQzWNS" crossorigin=""/>
 <style type="text/css">
@@ -21,7 +24,10 @@
 {{ super() }}
 <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js" integrity="sha384-sKs8ZrrxyJoElcPVznZwGpUTTXvkMYfHYxdIFzO8Hd0TA6emONMj8BwnsFf+6cZ/" crossorigin=""></script>
+<!-- 
 <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js" integrity="sha384-JP5UPxIO2Tm2o79Fb0tGYMa44jkWar53aBoCbd8ah0+LcCDoohTIYr+zIXyfGIJN" crossorigin=""></script>
+ -->
+<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.js" integrity="sha384-ld2Q6oJGnECCjh+LLDcIWiAxD4lZGgdYvhwDcp4Uhw23A8VSqQcD7YOoNHdwPjQc" crossorigin=""/></script>
 <script src="https://unpkg.com/@yaireo/tagify@2.31.6/dist/jQuery.tagify.min.js" integrity="sha384-oJRpUI+TNL56khhVpM5tcGH6Al77rv1qUUKXqmG0cMe5KtcNzLYfxgdcwunFouVe" crossorigin=""></script>
 <script src="https://unpkg.com/leaflet.locatecontrol@v0.79.0/dist/L.Control.Locate.min.js"  integrity="sha384-XF7O0sxpctKl96bCyBgbgdQbnHDg/ek0LdbWrVUmx/LPh4EDtdIsGculgF93z6wW" crossorigin=""></script>
 <script type="text/javascript">
@@ -86,7 +92,7 @@ $(document).ready(function() {
     tonerLayer.addTo(map);
 
     // Enable switching between map layers
-    var layerControl = L.control.layers(baseLayers, {}, { position: 'bottomright' });
+    var layerControl = L.control.layers(baseLayers, {}, { position: 'bottomleft' });
     layerControl.addTo(map);
 
     // Enable GPS based location for field work
@@ -263,47 +269,48 @@ $(document).ready(function() {
     // Create an instance of the custom control and add it to the map
     new ResetButton({ position: 'topright' }).addTo(map);
 
-    var drawControl = new L.Control.Draw({
-      position: 'topright',
-      draw: {
-        polyline: false,    // Remove line drawing option
-        circle: false,
-        marker: false,
-        circlemarker: enable_circlemarker,
-        polygon: enable_polygon,
-        rectangle: enable_rectangle
-      },
-      edit: {
-        featureGroup: drawnItems
-      }
+    // add Leaflet-Geoman controls with some options to the map  
+    var drawControl = map.pm.addControls({  
+      position: 'topright',  
+      drawPolyline: false,    // Remove line drawing option
+      drawCircle: false,
+      drawMarker: false,
+      drawText: false,
+      cutPolygon: false,
+      drawCirclemarker: enable_circlemarker,
+      drawPolygon: enable_polygon,
+      drawRectangle: enable_rectangle
     });
-    map.addControl(drawControl);
     
     function updateDrawOptions() {
       if( count_circlemarker >= 2 ) {
-        drawControl.setDrawingOptions({ circlemarker: false });
+        map.pm.setGlobalOptions({drawCirclemarker: false});
       } else {
-        drawControl.setDrawingOptions({ circlemarker: true });
+        map.pm.setGlobalOptions({drawCirclemarker: true});
       }
       if( count_polygon >= 1 ) {
-        drawControl.setDrawingOptions({ polygon: false });
+        map.pm.setGlobalOptions({drawPolygon: false});
       } else {
-        drawControl.setDrawingOptions({ polygon: true });
+        map.pm.setGlobalOptions({drawPolygon: true});
       }
       if( count_rectangle >= 1 ) {
-        drawControl.setDrawingOptions({ rectangle: false });
+        map.pm.setGlobalOptions({drawRectangle: false});
       } else {
-        drawControl.setDrawingOptions({ rectangle: true });
+        map.pm.setGlobalOptions({drawRectangle: true});
       }
       // to work around bug in the Leaflet Draw plugin, remove it and add it back for new options to take effect
       map.removeControl(drawControl);
       map.addControl(drawControl);
     }
 
-    map.on('draw:created', function (e) {
+    map.on('pm:create', function (e) {
       var layer = e.layer;
+      var shape = e.shape;
       
-      if (layer instanceof L.CircleMarker) {
+      console.log(layer);
+      console.log(shape);
+      
+      if (shape == 'CircleMarker') {
         if (count_circlemarker>=2) {
           map.removeLayer(layer);
           return;
@@ -383,7 +390,7 @@ $(document).ready(function() {
         labelPrompt.style.padding = '10px'; // Add padding
       
         map.getContainer().appendChild(labelPrompt);
-      } else if (layer instanceof L.Rectangle) {
+      } else if (shape == 'Rectangle') {
         // (nvkelso 20240329: Test Rectangle before Polygon because of Leaflet bug)
         layer.setStyle( options_label_bbox );
         layer.bindPopup(popup_text_label_bbox);
@@ -394,7 +401,7 @@ $(document).ready(function() {
         // needs to be after GUI setting
         document.getElementById('geom_label_bounding_box_text').value = `${layer.getBounds().getWest().toFixed(6)},${layer.getBounds().getSouth().toFixed(6)},${layer.getBounds().getEast().toFixed(6)},${layer.getBounds().getNorth().toFixed(6)}`;
         drawnItems.addLayer(layer);
-      } else if (layer instanceof L.Polygon) {
+      } else if (shape == 'Polygon') {
         layer.setStyle( options_default_geom_polygon );
         layer.bindPopup(popup_text_default_geom_polygon);
         document.getElementById('geom_default').checked = true;
@@ -409,6 +416,7 @@ $(document).ready(function() {
       }
     });
 
+    // This happens on "save" of the editing session
     map.on('draw:edited', function (e) {
       var layers = e.layers;
       layers.eachLayer(function (layer) {
@@ -417,6 +425,7 @@ $(document).ready(function() {
         }
       });
     });
+    
     $("input.wof-input").on("change", function() {
         checkValid($(this));
     });

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -132,7 +132,7 @@ $(document).ready(function() {
     //       The ideal z-ordering is below (not implemented)
     var options_default_geom_polygon = {color: geomColors.default, title: popup_text_default_geom_polygon};                     // zIndex: 100
     var options_default_geom_point = {color: geomColors.default, title: popup_text_default_geom_point};                         // zIndex: 203
-    var options_math_centroid = {color: geomColors.geomCentroid, radius: 5, draggable: true, title: popup_text_math_centroid};  // zIndex: 200
+    var options_math_centroid = {color: geomColors.geomCentroid, radius: 5, draggable: false, title: popup_text_math_centroid}; // zIndex: 200
     var options_label_centroid = {color: geomColors.labelPoint, draggable: true, title: popup_text_label_centroid};             // zIndex: 202
     var options_label_bbox = {color: geomColors.labelBbox, draggable: true, title: popup_text_label_bbox};                      // zIndex: 101
     var options_revGeo_centroid = {color: geomColors.revgeoPoint, draggable: true, title: popup_text_revGeo_centroid};          // zIndex: 201

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -94,12 +94,12 @@ $(document).ready(function() {
     // TODO: Leaflet requires the layer overlays to be added in incrementing z-order
     //       If you want to reorder, you have to remove all and then add back (omg)
     //       The ideal z-ordering is below (not implemented)
-    var options_default_geom_polygon = {color: geomColors.default};                           // zIndex: 100
-    var options_default_geom_point = {color: geomColors.default};                             // zIndex: 203
-    var options_math_centroid = {color: geomColors.geomCentroid, radius: 5, draggable: true}; // zIndex: 200
-    var options_label_centroid = {color: geomColors.labelPoint, draggable: true};             // zIndex: 202
-    var options_label_bbox = {color: geomColors.labelBbox, draggable: true};                  // zIndex: 101
-    var options_revGeo_centroid = {color: geomColors.revgeoPoint, draggable: true};           // zIndex: 201
+    var options_default_geom_polygon = {color: geomColors.default, title: popup_text_default_geom_polygon};                     // zIndex: 100
+    var options_default_geom_point = {color: geomColors.default, title: popup_text_default_geom_point};                         // zIndex: 203
+    var options_math_centroid = {color: geomColors.geomCentroid, radius: 5, draggable: true, title: popup_text_math_centroid};  // zIndex: 200
+    var options_label_centroid = {color: geomColors.labelPoint, draggable: true, title: popup_text_label_centroid};             // zIndex: 202
+    var options_label_bbox = {color: geomColors.labelBbox, draggable: true, title: popup_text_label_bbox};                      // zIndex: 101
+    var options_revGeo_centroid = {color: geomColors.revgeoPoint, draggable: true, title: popup_text_revGeo_centroid};          // zIndex: 201
     var z_offset_default_geom_polygon = 0;
     var z_offset_default_geom_point = 3;
     var z_offset_math_centroid = 0;
@@ -131,6 +131,8 @@ $(document).ready(function() {
       featureLayer.addData({{ {"type":"Feature","geometry":wof_doc.geometry}|tojson }});
       featureLayer.bindPopup(popup_text_default_geom_point);
       map.fitBounds(featureLayer.getBounds());
+      // TODO: This is more complicated, depending on Polygon or Point we'd update text, too
+      document.getElementById('geom_default').checked = true;
     
       // Only enable polygon drawing if the default geom is a point not a polygon
       {% if wof_doc.geometry['type'] != 'Point' -%}
@@ -155,6 +157,7 @@ $(document).ready(function() {
       enable_rectangle = false;
       count_rectangle++;
       has_label_bbox = true;
+      document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
       {%- endif %}
 
       {% if wof_doc.properties['geom:latitude'] is defined and wof_doc.properties['geom:longitude'] is defined -%}
@@ -164,6 +167,7 @@ $(document).ready(function() {
       // Add the CircleMarker to the drawnItems FeatureGroup to enable editing
       drawnItems.addLayer(geomCentroidLayer);
       has_math_centroid = true;
+      document.getElementById('geom_centroid').checked = has_math_centroid;
       {%- endif %}
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined -%}
@@ -174,6 +178,7 @@ $(document).ready(function() {
       drawnItems.addLayer(labelPointLayer);
       count_circlemarker++;
       has_label_centroid = true;
+      document.getElementById('geom_label_centroid').checked = has_label_centroid;
       {%- endif %}
 
       {% if wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
@@ -184,6 +189,7 @@ $(document).ready(function() {
       drawnItems.addLayer(reverseGeoLayer);
       count_circlemarker++;
       has_revGeo_centroid = true;
+      document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
       {%- endif %}
 
       {% if wof_doc.properties['lbl:latitude'] is defined and wof_doc.properties['lbl:longitude'] is defined and wof_doc.properties['reversegeo:latitude'] is defined and wof_doc.properties['reversegeo:longitude'] is defined -%}
@@ -249,6 +255,10 @@ $(document).ready(function() {
       // to work around bug in the Leaflet Draw plugin, remove it and add it back for new options to take effect
       map.removeControl(drawControl);
       map.addControl(drawControl);
+      
+      document.getElementById('geom_label_bounding_box').checked = has_label_bbox;
+      document.getElementById('geom_label_centroid').checked = has_label_centroid;
+      document.getElementById('geom_revgeo_centroid').checked = has_revGeo_centroid;
     }
 
     map.on('draw:created', function (e) {
@@ -298,11 +308,13 @@ $(document).ready(function() {
                 case popup_text_label_centroid: 
                   has_label_centroid = true;
                   layer.setStyle( options_label_centroid );
+                  document.getElementById('geom_label_centroid').checked = true;
                   // TODO: Add setting of WOF geometry
                   break;
                 case popup_text_revGeo_centroid: 
                   has_revGeo_centroid = true;
                   layer.setStyle(options_revGeo_centroid);
+                  document.getElementById('geom_revgeo_centroid').checked = true;
                   // TODO: Add setting of WOF geometry
                   break;
                 default:
@@ -336,6 +348,7 @@ $(document).ready(function() {
         // (nvkelso 20240329: Test Rectangle before Polygon because of Leaflet bug)
         layer.setStyle( options_label_bbox );
         layer.bindPopup(popup_text_label_bbox);
+        document.getElementById('geom_label_bounding_box').checked = true;
         count_rectangle++;
         has_label_bbox = true;
         updateDrawOptions();
@@ -344,6 +357,7 @@ $(document).ready(function() {
       } else if (layer instanceof L.Polygon) {
         layer.setStyle( options_default_geom_polygon );
         layer.bindPopup(popup_text_default_geom_polygon);
+        document.getElementById('geom_default').checked = true;
         count_polygon++;
         has_default_geom_polygon = true;
         has_default_geom_point = false;
@@ -373,11 +387,34 @@ $(document).ready(function() {
         if (layer instanceof L.CircleMarker) {
           label_centroid = false;
           count_circlemarker--;
-          updateDrawOptions();
         }
         if (layer.options && layer.options.title) {
-          console.log("Deleted layer title:", layer.options.title);
+          console.log("Finished deleting layer title:", layer.options.title);
+        
+          switch( layer.options.title ) {
+            case popup_text_label_centroid: 
+              has_label_centroid = false;
+              // TODO: Add setting of WOF geometry
+              break;
+            case popup_text_revGeo_centroid: 
+              has_revGeo_centroid = false;
+              // TODO: Add setting of WOF geometry
+              break;
+            case popup_text_label_bbox: 
+              has_label_bbox = false;
+              // TODO: Add setting of WOF geometry
+              break;
+            case popup_text_default_geom_polygon: 
+            case popup_text_default_geom_point: 
+            case popup_text_math_centroid: 
+              // TODO: these should warn and the geom restored (and not removed from database)
+              console.log("Ooops, this layer shouldn't be deleted:", layer.options.title);
+              break;
+            default:
+              break;
+          }
         }
+        updateDrawOptions();
       });
     });
 

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -446,36 +446,32 @@ $(document).ready(function() {
        
           // Loop through each layer on the map
           map.eachLayer(function(layer) {
-              // Check if the layer has a 'title' property and if it is equal to "foo"
               if (layer.options && layer.options.title === whichLayer) {
-                  // Move the layer on the map
                   layer.setLatLng([newLat, newLng]);
               }
           });
         } else if( whichLayer == popup_text_label_bbox ) {
-//           var inputLocation = document.getElementById('geom_label_bounding_box_text').value;
-// 
-//           // Split the input value on comma and parse latitude and longitude as floats
-//           var bboxParts = inputLocation.split(',');
-//           
-//           var labelBbox2 = L.latLngBounds(
-//               L.latLng(parseFloat(bboxParts[1]), parseFloat(bboxParts[0])),
-//               L.latLng(parseFloat(bboxParts[3]), parseFloat(bboxParts[2]))
-//           );
-//        
-//           // Loop through each layer on the map
-//           map.eachLayer(function(layer) {
-//               // Check if the layer has a 'title' property and if it is equal to "foo"
-//               if (layer.options && layer.options.title === whichLayer) {
-//                   // Move the layer on the map
-//                   layer.setBounds(labelBbox2);
-//               }
-//           });
+          var inputLocation = document.getElementById('geom_label_bounding_box_text').value;
+
+          // Split the input value on comma and parse latitude and longitude as floats
+          var bboxParts = inputLocation.split(',');
+          
+          var labelBbox2 = L.latLngBounds(
+              L.latLng(parseFloat(bboxParts[1]), parseFloat(bboxParts[0])),
+              L.latLng(parseFloat(bboxParts[3]), parseFloat(bboxParts[2]))
+          );
+       
+          // Loop through each layer on the map
+          map.eachLayer(function(layer) {
+              if (layer.options && layer.options.title === whichLayer) {
+                  layer.setBounds(labelBbox2);
+              }
+          });
         }
     }
 
     // This happens on "save" of the editing session
-    map.on('draw:edited', function (e) {
+    map.on('pm:edit', function (e) {
       var layers = e.layers;
       layers.eachLayer(function (layer) {
         if (layer.options && layer.options.title) {
@@ -497,7 +493,6 @@ $(document).ready(function() {
         removeLayer(popup_text_label_centroid);
     });
     $("#geom_label_centroid_text").on("change", function(event) {
-        console.log('TODO: Move label centroid to: ', event.target.value);
         updateLayer(popup_text_label_centroid);
     });
     $("#geom_label_bounding_box").on("change", function(event) {
@@ -509,7 +504,6 @@ $(document).ready(function() {
         removeLayer(popup_text_label_bbox);
     });
     $("#geom_label_bounding_box_text").on("change", function(event) {
-        console.log('TODO: Move label bbox to: ', event.target.value);
         updateLayer(popup_text_label_bbox);
     });
     $("#geom_revgeo_centroid").on("change", function(event) {
@@ -521,18 +515,12 @@ $(document).ready(function() {
         removeLayer(popup_text_revGeo_centroid);
     });
     $("#geom_revgeo_centroid_text").on("change", function(event) {
-        console.log('TODO: Move revGeo centroid to: ', event.target.value);
         updateLayer(popup_text_revGeo_centroid);
     });
     
-//     const inputElement = document.getElementById('geom_label_centroid');
-//     inputElement.addEventListener('change', function(event) {
-//       // Log the new value to the console
-//       console.log('New value:', event.target.value);
-//     });
-
     // Add event listener to modify label_centroid when a marker is deleted
-    map.on('draw:deleted', function (e) {
+    map.on('pm:update', function (e) {
+      console.log(e);
       var layers = e.layers;
       layers.eachLayer(function (layer) {
         if (layer instanceof L.CircleMarker) {

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -107,6 +107,8 @@ $(document).ready(function() {
         L.latLng({{ bboxParts[3] }}, {{ bboxParts[2] }}),
     );
     var labelBboxLayer = L.rectangle(labelBbox, {color: geomColors.labelBbox, title: 'label bounding box'}).addTo(drawnItems);
+    map.fitBounds(featureLayer.getBounds().extend(labelBboxLayer.getBounds()));
+    // Point default geoms sometimes have a label bounding box that is larger, zoom out to it
     labelBboxLayer.bindPopup("label bounding box");
     // Disable drawing rectangles if the label bounding box already exists
     enable_rectangle = false;

--- a/editor/templates/place/edit.html
+++ b/editor/templates/place/edit.html
@@ -58,12 +58,38 @@ $(document).ready(function() {
     }
 
     var map = L.map('map', {preferCanvas: true});
-    var baseLayer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png', {
+
+    // Base tile layers
+    var tonerLayer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png', {
         attribution: 'Map tiles by &copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> <a href="https://stamen.com/" target="_blank">&copy; Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>',
         minZoom: 0,
         maxZoom: 19
-    }).addTo(map);
+    });
 
+    var satelliteLayer = L.tileLayer('https://api.maptiler.com/maps/hybrid/{z}/{x}/{y}.jpg?key=Qi6Rx9Ks63CEDCgxcjET', {
+      attribution: '&copy; <a href="https://www.maptiler.com/">MapTiler</a>',
+      maxZoom: 19,
+    });
+
+    var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    });
+
+    // Layer control to switch between tile layers
+    var baseLayers = {
+      "Toner": tonerLayer,
+      "Satellite Hybrid": satelliteLayer,
+      "OpenStreetMap": osmLayer
+    };
+
+    // Add default Toner layer to map
+    tonerLayer.addTo(map);
+
+    // Enable switching between map layers
+    var layerControl = L.control.layers(baseLayers, {}, { position: 'bottomright' });
+    layerControl.addTo(map);
+
+    // Enable GPS based location for field work
     L.control.locate().addTo(map);
 
     var drawnItems = new L.FeatureGroup().addTo(map);


### PR DESCRIPTION
Changes:

- [x] Add new Leaflet Draw controls on right side of map
    - [x] Contextually adds circleMarker (label centroid and revGeo centroid), polygon (default geom), and rectangle (label bbox) options if those don't yet exist
    - [x] Prompt for which centroid geoms to add when adding a circlemarker
    - [x] Add ability to reset the edited geometries
    - [x] Draw new geoms using right colour
    - [ ] Not fully wired up to ~~create~~, edit, ~~delete~~ WOF geometries (it's unlinked now) in Leaflet Draw layer group
    - [ ] Not fully wired up to take those layer group edits and update the WOF record with them
    - [ ] v1 probably won't allow editing polygon geoms that aren't mapzen / wof sourced? Otherwise have to deal with alt geoms, oh my!?
- [x] Add new `Geometries` section at very top near map
    - [x] Checked is true for following if that type of geom already exists (as it can be hard to see on the map). Disabled (not check or uncheckable) for now – maybe in future it could delete or add that geom type?
    - [x]  Default geom (geometry) with source and area
    - [x]  Alternate geoms (geometry) and count of sources
    - [x]  Math centroid (geom.longitude, geom.latitude)
    - [x]  Label centroid (lbl.longitude, lbl.latitude)
    - [x]  Label bounding box (lbl.bbox)
    - [x]  Reverse geocoding centroid (reversegeo.longitude, reversegeo.latitude)
- [x] Add new header for existing `Common properties` section
- [ ] Adjust map geom colors (geom centroid should be black?)

Testing locations:

- [San Francisco](http://127.0.0.1:5000/place/edit?url=https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-us/master/data/859/225/83/85922583.geojson), CA, USA - `85922583` - Polygon, has label bbox and centroid, no revGeo centroid, multiple alternate geometries
- [New York](http://127.0.0.1:5000/place/edit?url=https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-us/master/data/859/775/39/85977539.geojson), NY, USA - `85977539` - Polygon, no label bbox, has label centroid, has revGeo centroid, multiple alternate geometries
- [Olopoto](http://127.0.0.1:5000/place/edit?url=https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-ng/master/data/132/729/337/1/1327293371.geojson), Nigera - `1327293371`  - Point, no extras at all. Now zooms out to the label bbox on init map / page load, no alternate geometries

Screenshot:

<img width="1124" alt="image" src="https://github.com/iandees/wof-editor/assets/853051/1b5c12ee-2e47-4af8-8c29-2466fe323094">