### PR TITLE
More specific GH pull request title

### DIFF
--- a/editor/place/views.py
+++ b/editor/place/views.py
@@ -334,6 +334,7 @@ def edit_place():
     wof_id = wof_doc['id']
     file_path = 'data/' + build_wof_doc_url_suffix(wof_id)
     place_name = wof_doc['properties'].get('wof:name')
+    place_type = wof_doc['properties'].get('wof:placetype')
 
     # Put localized_names and labels information in a more convenient container
     localized_names = parse_prefix_map(wof_doc['properties'], 'name:')
@@ -688,7 +689,7 @@ def edit_place():
         resp = sess.post(
             'https://api.github.com/repos/%s/pulls' % (base_repo,),
             json={
-                "title": "Update Place %s" % (place_name or wof_id),
+                "title": "Update %s %s" % (place_type or 'place', place_name or wof_id),
                 "head": (fork_owner + branch_name),
                 "base": "master",
                 "body": "Updating `%s` using the [WOF Editor](https://github.com/iandees/wof-editor)" % file_path,


### PR DESCRIPTION
When I browse PRs created by Write Field it's hard to parse the name of the place, because the casing in the PR title is all Tiltle Casing and `Place` looks like it's part of the place's name when it's not. 

Instead I'd like to know the feature's placetype (which is a proxy for how much effort the PR review will have based on it's downstream impact and scope), and that should be lowercase so it's easier to read the name part. To do this I add a new variable up top, and then modify the string substitution in the PR title creation.

Changes to:

- `Update country United States`
- `Update region New York`
- `Update locality Mill Valley`
- `Update neighbourhood Cole Valley`

From: 

- `Update Place United States`
- `Update Place New York`
- `Update Place Mill Valley`
- `Update Place Cole Valley`

@iandees I remember it was tricky to test the GH Pull Request part without a deploy. Can you help me with that part, please?